### PR TITLE
Format vector-db.md into a table

### DIFF
--- a/semantic-kernel/get-started/supported-languages.md
+++ b/semantic-kernel/get-started/supported-languages.md
@@ -84,6 +84,8 @@ Today, not all features are available in all languages. The following tables sho
 |--------------------------|:----:|:------:|:----:|-------|
 | Azure Cognitive Search   | ✅ | ✅ | ✅ | |
 | Chroma                   | ✅ | ✅ | ❌ | |
+| CosmosDB                 | ✅ | ❌ | ❌ | |
+| DuckDB                   | ✅ | ❌ | ❌ | |
 | Milvus                   | 🔄 | ✅ | ❌ | |
 | Pinecone                 | ✅ | ✅ | ❌ | |
 | Postgres                 | ✅ | ✅ | ❌ | Vector optimization requires [pgvector](https://github.com/pgvector/pgvector) |

--- a/semantic-kernel/memories/vector-db.md
+++ b/semantic-kernel/memories/vector-db.md
@@ -42,17 +42,21 @@ you can use a vector database to store the latest information about that topic a
 ## Available connectors to vector databases
 Today, we have several connectors to vector databases that you can use to store and retrieve information. These include:
 
-- [Azure Cognitive Search](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.AzureCognitiveSearch) .net and [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/azure_cognitive_search)
-- [Chroma](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/chroma) .net and [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/chroma)
-- [COSMOS DB](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.CosmosDB)
-- [Milvus](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/milvus) in Python
-- [Redis](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Redis)
-- [Pinecone](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Pinecone) .net and [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/pinecone)
-- [Postgres](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Postgres) .net and [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/postgres)
-- [Qdrant](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Qdrant)
-- [Redis](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Redis)
-- [Sqlite](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Sqlite)
-- [Weaviate](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Weaviate) .net and [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/weaviate)
+
+| Service                  |    |  |  |
+|--------------------------|:----:|:------:|:----:|
+| Azure Cognitive Search   | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.AzureCognitiveSearch) | [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/azure_cognitive_search) |  |
+| Chroma                   | [C#](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/chroma) | [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/chroma) |  |
+| CosmosDB                 | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.CosmosDB) |  |  |
+| DuckDB                   | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.DuckDB) |  |  |
+| Milvus                   |  | [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/milvus) |  |
+| Pinecone                 | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Pinecone) | [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/pinecone) |  |
+| Postgres                 | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Postgres) | [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/postgres) |  |
+| Qdrant                   | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Qdrant) |  |  |
+| Redis                    | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Redis) |  |  |
+| Sqlite                    | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Sqlite) |  |  |
+| Weaviate                 | [C#](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Connectors/Connectors.Memory.Weaviate) | [Python](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/connectors/memory/weaviate) |  |
+
 
 ## Take the next step
 

--- a/semantic-kernel/memories/vector-db.md
+++ b/semantic-kernel/memories/vector-db.md
@@ -32,7 +32,7 @@ One use case for storing information in a vector database is to enable large lan
 an [AI plugin](../create-plugins/index.md). 
 
 However, large language models often face challenges such as generating inaccurate or irrelevant information; lacking factual consistency or common sense; repeating or contradicting themselves; being biased or offensive. To overcome these challenges,
-you can use a vector database to store information about different topics,keywords,facts,opinions,sources, related to your desired domain or genre.
+you can use a vector database to store information about different topics, keywords, facts, opinions, and/or sources related to your desired domain or genre.
 Then, you can use a large language model and pass information from the vector database with your AI plugin to generate more informative and engaging content that matches your intent and style.
 
 For example,


### PR DESCRIPTION
As proposed in #29, `vector-db.md` is now in a table format to match up with other files. There is a blank column left for when the Java implementation of memory connectors is available.

I also spotted an sentence where spaces were not present after commas.

Thanks!