### PR TITLE
Fixed broken link C# Core Skills

### DIFF
--- a/semantic-kernel/ai-orchestration/out-of-the-box-plugins.md
+++ b/semantic-kernel/ai-orchestration/out-of-the-box-plugins.md
@@ -32,7 +32,7 @@ The core plugins are planned to be available in all languages since they are cor
 | `WaitSkill` | To pause execution for a specified amount of time | ✅ | ❌ | ❌ |
 
 You can find the full list of core plugins for each language by following the links below:
-- [C# core plugins](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/SemanticKernel/CoreSkills)
+- [C# core plugins](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Skills/Skills.Core)
 - [Python core plugins](https://github.com/microsoft/semantic-kernel/tree/main/python/semantic_kernel/core_skills)
 
 ### Using core plugins in Semantic Kernel


### PR DESCRIPTION
link to C# core plugins was broken. I have updated it to point to the latest location