### PR TITLE
Add missing version for planner package

### DIFF
--- a/samples/dotnet/Directory.Packages.props
+++ b/samples/dotnet/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel" Version="0.21.230828.2-preview" />
     <PackageVersion Include="Microsoft.SemanticKernel.Skills.OpenAPI" Version="0.21.230828.2-preview" />
     <PackageVersion Include="Microsoft.SemanticKernel.Planning.StepwisePlanner" Version="0.21.230828.2-preview" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" Version="0.21.230828.2-preview" />
     <PackageVersion Include="Microsoft.SemanticKernel.Skills.Core" Version="0.21.230828.2-preview" />
     <!-- Microsoft.Azure -->
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />


### PR DESCRIPTION
This PR adds the version that's missing for the **Microsoft.SemanticKernel.Planning.SequentialPlanner** package.

Before this PR, the steps to reproduce the problem when `main` was on 1c43b1fd4e36bfb7a5d7a5773fce5b7cf5130ed0 (at time of reporting):

    git clone https://github.com/MicrosoftDocs/semantic-kernel-docs.git
    cd semantic-kernel-docs
    git checkout 1c43b1fd4e36bfb7a5d7a5773fce5b7cf5130ed0
    cd samples/dotnet
    dotnet restore

The output should be (note error NU1010 indicating that `PackageReference` items `Microsoft.SemanticKernel.Planning.SequentialPlanner` do not have corresponding `PackageVersion`):

      Determining projects to restore...
    t:\semantic-kernel-docs\samples\dotnet\11-Planner\11-Planner.csproj : error NU1010: The PackageReference items Microsoft.SemanticKernel.Planning.SequentialPlanner do not have corresponding PackageVersion. [T:\semantic-kernel-docs\samples\dotnet\dotnet.sln]
      Failed to restore t:\semantic-kernel-docs\samples\dotnet\11-Planner\11-Planner.csproj (in 60 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\13-Create-ChatGPT-Plugin\MathPlugin\semantic-functions-generator\semantic-functions-generator.csproj (in 353 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\06-Calling-Nested-Functions-in-Semantic-Functions\06-Calling-Nested-Functions-In-Semantic-Functions.csproj (in 385 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\13-Create-ChatGPT-Plugin\Solution\13-Create-ChatGPT-Plugin.csproj (in 385 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\05-Templatizing-Semantic-Functions\05-Templatizing-Semantic-Functions.csproj (in 384 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\10-Chaining-Functions\10-Chaining-Functions.csproj (in 203 ms).
      Restored t:\semantic-kernel-docs\samples\dotnet\02-Adding-AI-Services\02-Adding-AI-Services.csproj (in 292 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\03-Inline-Semantic-Functions\03-Inline-Semantic-Functions.csproj (in 385 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\01-Kernel-Intro\01-Kernel-Intro.csproj (in 68 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\09-Calling-Nested-Functions-in-Native-Functions\09-Calling-Nested-Functions-in-Native-Functions.csproj (in 52 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\13-Create-ChatGPT-Plugin\MathPlugin\azure-function\sk-chatgpt-azure-function.csproj (in 775 ms).
      3 of 14 projects are up-to-date for restore.

After applying this PR, the same steps produce an output without any errors:

      Determining projects to restore...
      Restored T:\semantic-kernel-docs\samples\dotnet\07-Simple-Native-Functions\07-Simple-Native-Functions.csproj (in 342 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\01-Kernel-Intro\01-Kernel-Intro.csproj (in 432 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\08-Native-Functions-with-Context\08-Native-Functions-with-Context.csproj (in 432 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\05-Templatizing-Semantic-Functions\05-Templatizing-Semantic-Functions.csproj (in 431 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\06-Calling-Nested-Functions-in-Semantic-Functions\06-Calling-Nested-Functions-In-Semantic-Functions.csproj (in 432 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\09-Calling-Nested-Functions-in-Native-Functions\09-Calling-Nested-Functions-in-Native-Functions.csproj (in 342 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\04-Serializing-Semantic-Functions\04-Serializing-Semantic-Functions.csproj (in 431 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\03-Inline-Semantic-Functions\03-Inline-Semantic-Functions.csproj (in 19 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\11-Planner\11-Planner.csproj (in 30 ms).
      Restored T:\semantic-kernel-docs\samples\dotnet\13-Create-ChatGPT-Plugin\MathPlugin\azure-function\sk-chatgpt-azure-function.csproj (in 909 ms).
      4 of 14 projects are up-to-date for restore.

## Other Information:

`dotnet --info` says:

    .NET SDK:
     Version:   7.0.401
     Commit:    eb26aacfec

    Runtime Environment:
     OS Name:     Windows
     OS Version:  10.0.22621
     OS Platform: Windows
     RID:         win10-x64
     Base Path:   C:\Program Files\dotnet\sdk\7.0.401\

    Host:
      Version:      7.0.11
      Architecture: x64
      Commit:       ecb34f85ec

    .NET SDKs installed:
      3.1.426 [C:\Program Files\dotnet\sdk]
      5.0.416 [C:\Program Files\dotnet\sdk]
      6.0.414 [C:\Program Files\dotnet\sdk]
      7.0.203 [C:\Program Files\dotnet\sdk]
      7.0.401 [C:\Program Files\dotnet\sdk]

    .NET runtimes installed:
      Microsoft.AspNetCore.App 3.1.32 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
      Microsoft.AspNetCore.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
      Microsoft.AspNetCore.App 6.0.22 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
      Microsoft.AspNetCore.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
      Microsoft.AspNetCore.App 7.0.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
      Microsoft.NETCore.App 3.1.32 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      Microsoft.NETCore.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      Microsoft.NETCore.App 6.0.22 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      Microsoft.NETCore.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      Microsoft.NETCore.App 7.0.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      Microsoft.WindowsDesktop.App 3.1.32 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
      Microsoft.WindowsDesktop.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
      Microsoft.WindowsDesktop.App 6.0.22 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
      Microsoft.WindowsDesktop.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
      Microsoft.WindowsDesktop.App 7.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

    Other architectures found:
      x86   [C:\Program Files (x86)\dotnet]
        registered at [HKLM\SOFTWARE\dotnet\Setup\InstalledVersions\x86\InstallLocation]

    Environment variables:
      Not set

    global.json file:
      Not found

    Learn more:
      https://aka.ms/dotnet/info

    Download .NET:
      https://aka.ms/dotnet/download
