### PR TITLE
adding completion service to Kernel is working for Azure OpenAI but not for OpenAI

### DIFF
--- a/samples/python/03-Inline-Semantic-Functions/config/add_completion_service.py
+++ b/samples/python/03-Inline-Semantic-Functions/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/04-Serializing-Semantic-Functions/config/add_completion_service.py
+++ b/samples/python/04-Serializing-Semantic-Functions/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/05-Templatizing-Semantic-Functions/config/add_completion_service.py
+++ b/samples/python/05-Templatizing-Semantic-Functions/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/06-Calling-Nested-Functions-in-Semantic-Functions/config/add_completion_service.py
+++ b/samples/python/06-Calling-Nested-Functions-in-Semantic-Functions/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/07-Simple-Native-Functions/config/add_completion_service.py
+++ b/samples/python/07-Simple-Native-Functions/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/08-Native-Functions-with-Context/config/add_completion_service.py
+++ b/samples/python/08-Native-Functions-with-Context/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/09-Calling-Nested-Functions-in-Native-Functions/config/add_completion_service.py
+++ b/samples/python/09-Calling-Nested-Functions-in-Native-Functions/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/10-Chaining-Functions/config/add_completion_service.py
+++ b/samples/python/10-Chaining-Functions/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service

--- a/samples/python/11-Planner/config/add_completion_service.py
+++ b/samples/python/11-Planner/config/add_completion_service.py
@@ -36,11 +36,10 @@ def add_completion_service(self):
                 ),
             )
     else:
-        model_id = config.get("AZURE_OPEN_AI__MODEL_ID", None)
+        model_id = config.get("OPEN_AI__MODEL_TYPE", None)
 
         if model_id == "chat-completion":
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_chat_service(
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
@@ -49,8 +48,7 @@ def add_completion_service(self):
                 ),
             )
         else:
-            kernel = sk.Kernel()
-            kernel.add_text_completion_service(
+            self.add_text_completion_service(
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
@@ -58,6 +56,5 @@ def add_completion_service(self):
                     config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
-
 
 Kernel.add_completion_service = add_completion_service


### PR DESCRIPTION
It looks like something went wrong while building the `config/add_completion_service.py` file. The completion service gets added to the Kernel when defining the `LLM_SERVICE` as `AzureOpenAI`, but not when using `OpenAI`.

1. The wrong environment variable was used, it was still referencing the AzureOpenAI ID, while choosing the OpenAI LLM service.
2. The way how the chat service or completion service was creation didn't work as it was creating a new kernel instead of extending the existing kernel.

Hopes this helps ;) For me at least it now works with both LLM services. Thanks for the great tutorials!
Cedric
