### PR TITLE
Update out-of-the-box-plugins.md

### DIFF
--- a/semantic-kernel/ai-orchestration/plugins/out-of-the-box-plugins.md
+++ b/semantic-kernel/ai-orchestration/plugins/out-of-the-box-plugins.md
@@ -25,7 +25,7 @@ The core plugins are planned to be available in all languages since they are cor
 | `TextMemoryPlugin` | To store and retrieve text in memory | ✅ | ✅ | ❌ |
 | `TextPlugin` | To deterministically manipulating text strings | ✅ | ✅ | * |
 | `TimePlugin` | To acquire the time of day and any other temporal information | ✅ | ✅ | * |
-| `WaitPlugin` | To pause execution for a specified amount of time | ✅ | ❌ | ❌ |
+| `WaitPlugin` | To pause execution for a specified amount of time | ✅ | ✅ | ❌ |
 
 You can find the full list of core plugins for each language by following the links below:
 - [C# core plugins](https://github.com/microsoft/semantic-kernel/tree/main/dotnet/src/Plugins/Plugins.Core)


### PR DESCRIPTION
Python supports waitPlugin as part of Core plugin : 
[python/semantic_kernel/core_skills/wait_skill.py](https://github.com/microsoft/semantic-kernel/blob/main/python/semantic_kernel/core_skills/wait_skill.py)