### PR TITLE
Fixed incorrect Handlebars syntax

### DIFF
--- a/samples/dotnet/04-Templatizing-Prompts/Program.cs
+++ b/samples/dotnet/04-Templatizing-Prompts/Program.cs
@@ -51,7 +51,7 @@ var getIntent = kernel.CreateFunctionFromPrompt(
     {
         Template = @"
         <message role=""system"">Instructions: What is the intent of this request?
-        Do not explain the reasoning, just reply back with the intent. If you are unsure, reply with {{choices[0]}}.
+        Do not explain the reasoning, just reply back with the intent. If you are unsure, reply with {{choices.0}}.
         Choices: {{choices}}.</message>
 
         {{#each fewShotExamples}}


### PR DESCRIPTION
It seems the `choices[0]` syntax is not the correct one for handlebars, but rather either `choices.0` or `choices.[0]`.

(This was found when attempting to use SK with a local Ollama)

