### PR TITLE
Upgrade Python semantic-kernel to version 0.4.6.dev0

### DIFF
--- a/samples/python/01-Kernel-Intro/main.py
+++ b/samples/python/01-Kernel-Intro/main.py
@@ -1,7 +1,7 @@
 async def main():
     from dotenv import dotenv_values
     import semantic_kernel as sk
-    from semantic_kernel.core_skills import TimeSkill
+    from semantic_kernel.core_plugins import TimePlugin
     from semantic_kernel.connectors.ai.open_ai import (
         OpenAIChatCompletion,
         AzureChatCompletion,
@@ -33,12 +33,12 @@ async def main():
             ),
         )
 
-    # Import the TimeSkill
-    time = kernel.import_skill(TimeSkill())
+    # Import the TimePlugin
+    time = kernel.import_plugin(TimePlugin())
 
     # Import the WriterPlugin from the plugins directory.
     plugins_directory = "./plugins"
-    writer_plugin = kernel.import_semantic_skill_from_directory(
+    writer_plugin = kernel.import_semantic_plugin_from_directory(
         plugins_directory, "WriterPlugin"
     )
 

--- a/samples/python/01-Kernel-Intro/main.py
+++ b/samples/python/01-Kernel-Intro/main.py
@@ -19,8 +19,8 @@ async def main():
             "chat_completion",
             AzureChatCompletion(
                 config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                config.get("AZURE_OPEN_AI__API_KEY", None),
+                endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
             ),
         )
     else:
@@ -28,8 +28,8 @@ async def main():
             "chat_completion",
             OpenAIChatCompletion(
                 config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                config.get("OPEN_AI__API_KEY", None),
-                config.get("OPEN_AI__ORG_ID", None),
+                api_key=config.get("OPEN_AI__API_KEY", None),
+                org_id=config.get("OPEN_AI__ORG_ID", None),
             ),
         )
 

--- a/samples/python/01-Kernel-Intro/pyproject.toml
+++ b/samples/python/01-Kernel-Intro/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/02-Adding-AI-Services/main.py
+++ b/samples/python/02-Adding-AI-Services/main.py
@@ -62,7 +62,7 @@ async def main():
     plugins_directory = "./plugins"
 
     # Import the WriterPlugin from the plugins directory.
-    writer_plugin = kernel.import_semantic_skill_from_directory(
+    writer_plugin = kernel.import_semantic_plugin_from_directory(
         plugins_directory, "WriterPlugin"
     )
 

--- a/samples/python/02-Adding-AI-Services/main.py
+++ b/samples/python/02-Adding-AI-Services/main.py
@@ -21,8 +21,8 @@ async def main():
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ async def main():
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -44,8 +44,8 @@ async def main():
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -54,8 +54,8 @@ async def main():
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/02-Adding-AI-Services/pyproject.toml
+++ b/samples/python/02-Adding-AI-Services/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/03-Intro-to-Prompts/config/add_completion_service.py
+++ b/samples/python/03-Intro-to-Prompts/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/03-Intro-to-Prompts/pyproject.toml
+++ b/samples/python/03-Intro-to-Prompts/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/04-Templatizing-Prompts/config/add_completion_service.py
+++ b/samples/python/04-Templatizing-Prompts/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/04-Templatizing-Prompts/pyproject.toml
+++ b/samples/python/04-Templatizing-Prompts/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/05-Nested-Functions-In-Prompts/config/add_completion_service.py
+++ b/samples/python/05-Nested-Functions-In-Prompts/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/05-Nested-Functions-In-Prompts/main.py
+++ b/samples/python/05-Nested-Functions-In-Prompts/main.py
@@ -1,6 +1,6 @@
 async def main():
     import semantic_kernel as sk
-    from semantic_kernel.core_skills import ConversationSummarySkill
+    from semantic_kernel.core_plugins import ConversationSummaryPlugin
     import config.add_completion_service
 
     # Initialize the kernel
@@ -11,8 +11,8 @@ async def main():
     kernel.add_completion_service()
 
     # Import the ConversationSummaryPlugin
-    kernel.import_skill(
-        ConversationSummarySkill(kernel=kernel), skill_name="ConversationSummaryPlugin"
+    kernel.import_plugin(
+        ConversationSummaryPlugin(kernel=kernel), plugin_name="ConversationSummaryPlugin"
     )
 
     # Create the history

--- a/samples/python/05-Nested-Functions-In-Prompts/pyproject.toml
+++ b/samples/python/05-Nested-Functions-In-Prompts/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/06-Configuring-Prompts/config/add_completion_service.py
+++ b/samples/python/06-Configuring-Prompts/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/06-Configuring-Prompts/main.py
+++ b/samples/python/06-Configuring-Prompts/main.py
@@ -1,6 +1,6 @@
 async def main():
     import semantic_kernel as sk
-    from semantic_kernel.core_skills import ConversationSummarySkill
+    from semantic_kernel.core_plugins import ConversationSummaryPlugin
     import config.add_completion_service
 
     # Initialize the kernel
@@ -11,8 +11,8 @@ async def main():
     kernel.add_completion_service()
 
     # Import the ConversationSummaryPlugin
-    kernel.import_skill(
-        ConversationSummarySkill(kernel=kernel), skill_name="ConversationSummaryPlugin"
+    kernel.import_plugin(
+        ConversationSummaryPlugin(kernel=kernel), plugin_name="ConversationSummaryPlugin"
     )
 
     # Create the history

--- a/samples/python/06-Configuring-Prompts/pyproject.toml
+++ b/samples/python/06-Configuring-Prompts/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/07-Serializing-Prompts/config/add_completion_service.py
+++ b/samples/python/07-Serializing-Prompts/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/07-Serializing-Prompts/main.py
+++ b/samples/python/07-Serializing-Prompts/main.py
@@ -1,6 +1,6 @@
 async def main():
     import semantic_kernel as sk
-    from semantic_kernel.core_skills import ConversationSummarySkill
+    from semantic_kernel.core_plugins import ConversationSummaryPlugin
     import config.add_completion_service
 
     # Initialize the kernel
@@ -11,12 +11,12 @@ async def main():
     kernel.add_completion_service()
 
     # Import the ConversationSummaryPlugin
-    kernel.import_skill(
-        ConversationSummarySkill(kernel=kernel), skill_name="ConversationSummaryPlugin"
+    kernel.import_plugin(
+        ConversationSummaryPlugin(kernel=kernel), plugin_name="ConversationSummaryPlugin"
     )
 
     # Import the OrchestratorPlugin from the plugins directory.
-    prompts = kernel.import_semantic_skill_from_directory(".", "prompts")
+    prompts = kernel.import_semantic_plugin_from_directory(".", "prompts")
 
     # Create the history
     history = []

--- a/samples/python/07-Serializing-Prompts/pyproject.toml
+++ b/samples/python/07-Serializing-Prompts/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/08-Creating-Functions-For-AI/config/add_completion_service.py
+++ b/samples/python/08-Creating-Functions-For-AI/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/08-Creating-Functions-For-AI/main.py
+++ b/samples/python/08-Creating-Functions-For-AI/main.py
@@ -12,7 +12,7 @@ async def main():
     kernel.add_completion_service()
 
     # Import the MathPlugin.
-    math_plugin = kernel.import_skill(MathPlugin(), skill_name="MathPlugin")
+    math_plugin = kernel.import_plugin(MathPlugin(), plugin_name="MathPlugin")
 
     # Run the Sqrt function with the context.
     result = await kernel.run_async(

--- a/samples/python/08-Creating-Functions-For-AI/plugins/MathPlugin.py
+++ b/samples/python/08-Creating-Functions-For-AI/plugins/MathPlugin.py
@@ -1,5 +1,5 @@
 import math
-from semantic_kernel.skill_definition import (
+from semantic_kernel.plugin_definition import (
     sk_function,
     sk_function_context_parameter,
 )

--- a/samples/python/08-Creating-Functions-For-AI/pyproject.toml
+++ b/samples/python/08-Creating-Functions-For-AI/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/11-Planner/config/add_completion_service.py
+++ b/samples/python/11-Planner/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/11-Planner/main.py
+++ b/samples/python/11-Planner/main.py
@@ -12,7 +12,7 @@ async def main():
     kernel.add_completion_service()
 
     # Import the native functions
-    math_plugin = kernel.import_skill(Math(), "MathPlugin")
+    math_plugin = kernel.import_plugin(Math(), "MathPlugin")
 
     planner = SequentialPlanner(kernel)
 

--- a/samples/python/11-Planner/plugins/MathPlugin/Math.py
+++ b/samples/python/11-Planner/plugins/MathPlugin/Math.py
@@ -1,5 +1,5 @@
 import math
-from semantic_kernel.skill_definition import (
+from semantic_kernel.plugin_definition import (
     sk_function,
     sk_function_context_parameter,
 )

--- a/samples/python/11-Planner/pyproject.toml
+++ b/samples/python/11-Planner/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
+++ b/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
@@ -29,8 +29,8 @@ def my_python_tool(
             "chat_completion",
             AzureChatCompletion(
                 deployment_name,
-                AzureOpenAIConnection.api_base,
-                AzureOpenAIConnection.api_key,
+                endpoint=AzureOpenAIConnection.api_base,
+                api_key=AzureOpenAIConnection.api_key,
             ),
         )
     elif deployment_type == "text-completion":
@@ -38,8 +38,8 @@ def my_python_tool(
             "text_completion",
             AzureTextCompletion(
                 deployment_name,
-                AzureOpenAIConnection.api_base,
-                AzureOpenAIConnection.api_key,
+                endpoint=AzureOpenAIConnection.api_base,
+                api_key=AzureOpenAIConnection.api_key,
             ),
         )
 

--- a/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
+++ b/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
@@ -46,7 +46,7 @@ def my_python_tool(
     planner = SequentialPlanner(kernel=kernel)
 
     # Import the native functions
-    math_plugin = kernel.import_skill(Math(), "MathPlugin")
+    math_plugin = kernel.import_plugin(Math(), "MathPlugin")
 
     ask = "Use the available math functions to solve this word problem: " + input
 
@@ -56,7 +56,7 @@ def my_python_tool(
     result = asyncio.run(kernel.run_async(plan)).result
 
     for index, step in enumerate(plan._steps):
-        print("Function: " + step.skill_name + "." + step._function.name)
+        print("Function: " + step.plugin_name + "." + step._function.name)
         print("Input vars: " + str(step.parameters.variables))
         print("Output vars: " + str(step._outputs))
     print("Result: " + str(result))

--- a/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/plugins/MathPlugin/Math.py
+++ b/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/plugins/MathPlugin/Math.py
@@ -1,5 +1,5 @@
 import math
-from semantic_kernel.skill_definition import (
+from semantic_kernel.plugin_definition import (
     sk_function,
     sk_function_context_parameter,
 )

--- a/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/requirements.txt
+++ b/samples/python/12-Evaluate-with-Prompt-Flow/perform_math/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow-sdk[builtins]
-semantic-kernel==0.3.12.dev0
+semantic-kernel==0.4.6.dev0

--- a/samples/python/12-Evaluate-with-Prompt-Flow/pyproject.toml
+++ b/samples/python/12-Evaluate-with-Prompt-Flow/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = "^3.8"
 semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
+promptflow = "^1.4.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/samples/python/12-Evaluate-with-Prompt-Flow/pyproject.toml
+++ b/samples/python/12-Evaluate-with-Prompt-Flow/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/config/add_completion_service.py
+++ b/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/config/add_completion_service.py
@@ -22,8 +22,8 @@ def add_completion_service(self):
                 "chat_completion",
                 AzureChatCompletion(
                     config.get("AZURE_OPEN_AI__CHAT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
         else:
@@ -31,8 +31,8 @@ def add_completion_service(self):
                 "text_completion",
                 AzureTextCompletion(
                     config.get("AZURE_OPEN_AI__TEXT_COMPLETION_DEPLOYMENT_NAME", None),
-                    config.get("AZURE_OPEN_AI__ENDPOINT", None),
-                    config.get("AZURE_OPEN_AI__API_KEY", None),
+                    endpoint=config.get("AZURE_OPEN_AI__ENDPOINT", None),
+                    api_key=config.get("AZURE_OPEN_AI__API_KEY", None),
                 ),
             )
     else:
@@ -43,8 +43,8 @@ def add_completion_service(self):
                 "chat_completion",
                 OpenAIChatCompletion(
                     config.get("OPEN_AI__CHAT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
         else:
@@ -52,8 +52,8 @@ def add_completion_service(self):
                 "text_completion",
                 OpenAITextCompletion(
                     config.get("OPEN_AI__TEXT_COMPLETION_MODEL_ID", None),
-                    config.get("OPEN_AI__API_KEY", None),
-                    config.get("OPEN_AI__ORG_ID", None),
+                    api_key=config.get("OPEN_AI__API_KEY", None),
+                    org_id=config.get("OPEN_AI__ORG_ID", None),
                 ),
             )
 

--- a/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
+++ b/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
@@ -25,8 +25,8 @@ def my_python_tool(
             "chat_completion",
             AzureChatCompletion(
                 deployment_name,
-                AzureOpenAIConnection.api_base,
-                AzureOpenAIConnection.api_key,
+                endpoint=AzureOpenAIConnection.api_base,
+                api_key=AzureOpenAIConnection.api_key,
             ),
         )
     elif deployment_type == "text-completion":
@@ -34,8 +34,8 @@ def my_python_tool(
             "text_completion",
             AzureTextCompletion(
                 deployment_name,
-                AzureOpenAIConnection.api_base,
-                AzureOpenAIConnection.api_key,
+                endpoint=AzureOpenAIConnection.api_base,
+                api_key=AzureOpenAIConnection.api_key,
             ),
         )
 

--- a/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
+++ b/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/math_planner.py
@@ -42,7 +42,7 @@ def my_python_tool(
     planner = SequentialPlanner(kernel=kernel)
 
     # Import the native functions
-    math_plugin = kernel.import_skill(Math(), "MathPlugin")
+    math_plugin = kernel.import_plugin(Math(), "MathPlugin")
 
     ask = "Use the available math functions to solve this word problem: " + input
     ask += "\n\n"
@@ -55,7 +55,7 @@ def my_python_tool(
     result = asyncio.run(kernel.run_async(plan)).result
 
     for index, step in enumerate(plan._steps):
-        print("Function: " + step.skill_name + "." + step._function.name)
+        print("Function: " + step.plugin_name + "." + step._function.name)
         print("Input vars: " + str(step.parameters.variables))
         print("Output vars: " + str(step._outputs))
     print("Result: " + str(result))

--- a/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/plugins/MathPlugin/Math.py
+++ b/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/plugins/MathPlugin/Math.py
@@ -1,5 +1,5 @@
 import math
-from semantic_kernel.skill_definition import (
+from semantic_kernel.plugin_definition import (
     sk_function,
     sk_function_context_parameter,
 )

--- a/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/requirements.txt
+++ b/samples/python/13-Improved-Evaluate-with-Prompt-Flow/perform_math/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow-sdk[builtins]
-semantic-kernel==0.3.12.dev0
+semantic-kernel==0.4.6.dev0

--- a/samples/python/13-Improved-Evaluate-with-Prompt-Flow/pyproject.toml
+++ b/samples/python/13-Improved-Evaluate-with-Prompt-Flow/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = "^3.8"
 semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
+promptflow = "^1.4.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/samples/python/13-Improved-Evaluate-with-Prompt-Flow/pyproject.toml
+++ b/samples/python/13-Improved-Evaluate-with-Prompt-Flow/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-semantic-kernel = "^0.3.13.dev0"
+semantic-kernel = "^0.4.6.dev0"
 python-dotenv = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Upgrades the Python samples to use version 0.4.6.dev0 of `semantic-kernel`. It fixes incompatibilities created by the new version:
- Renaming  skills to plugins.
- Updating initializer parameter for the completion classes.
- Adding `promptflow` dependency for PromptFlow samples.