### PR TITLE
Update dotnet build command in README.md

### DIFF
--- a/samples/dotnet/14-Create-ChatGPT-Plugin/MathPlugin/README.md
+++ b/samples/dotnet/14-Create-ChatGPT-Plugin/MathPlugin/README.md
@@ -50,7 +50,7 @@ To build and run the Azure Functions application from a terminal use the followi
 
 ```powershell
 cd azure-function
-dotnet build
+dotnet build dotnet build sk-chatgpt-azure-function.csproj
 cd bin/Debug/net8.0
 func host start
 ```


### PR DESCRIPTION
`dotnet build` command needs to specify the project to compile since there are both a sln and csproj files

So the fix simply allows users to copy paste with the required arguments.
After that the build is successful and it is possible to start and open the swagger ui interface in the browser

(came upon this as part of https://learn.microsoft.com/en-us/semantic-kernel/agents/plugins/openai-plugins)