### PR TITLE
fix: Update history rendering template from Liquid to Handlebars

### DIFF
--- a/semantic-kernel/concepts/prompts/handlebars-prompt-templates.md
+++ b/semantic-kernel/concepts/prompts/handlebars-prompt-templates.md
@@ -63,11 +63,11 @@ string template = """
 
         Make sure to reference the customer by name response.
     </message>
-    {% for item in history %}
-    <message role="{{item.role}}">
-        {{item.content}}
-    </message>
-    {% endfor %}
+    {{#each history}}
+      <message role="{{this.role}}">
+        {{this.content}}
+      </message>
+    {{/each}}
     """;
 
 // Input data for the prompt rendering and execution


### PR DESCRIPTION
**Description:**
Updated the history rendering template in the Semantic Kernel GitHub prompt section to use Handlebars syntax ({{#each}}) instead of Liquid ({% for %}). This change ensures compatibility with Handlebars, which does not support the Liquid templating format.

- Replaced {% for item in history %} with {{#each history}} for iteration. 
- Updated property references from item.role and item.content to this.role and this.content. This fix resolves template parsing errors in environments using Handlebars.

**Testing:**

Verified proper rendering of history data after template adjustment. Ensured no syntax errors in Handlebars template rendering.