### PR TITLE
Fix: Add missing init command

### DIFF
--- a/semantic-kernel/Frameworks/agent/examples/example-agent-collaboration.md
+++ b/semantic-kernel/Frameworks/agent/examples/example-agent-collaboration.md
@@ -104,6 +104,9 @@ This sample requires configuration setting in order to connect to remote service
 ::: zone pivot="programming-language-csharp"
 
 ```powershell
+# Init user secrets
+dotnet user-secrets init
+
 # Open AI
 dotnet user-secrets set "OpenAISettings:ApiKey" "<api-key>"
 dotnet user-secrets set "OpenAISettings:ChatModel" "gpt-4o"

--- a/semantic-kernel/Frameworks/agent/examples/example-assistant-code.md
+++ b/semantic-kernel/Frameworks/agent/examples/example-assistant-code.md
@@ -109,6 +109,9 @@ This sample requires configuration setting in order to connect to remote service
 ::: zone pivot="programming-language-csharp"
 
 ```powershell
+# Init user secrets
+dotnet user-secrets init
+
 # Open AI
 dotnet user-secrets set "OpenAISettings:ApiKey" "<api-key>"
 dotnet user-secrets set "OpenAISettings:ChatModel" "gpt-4o"

--- a/semantic-kernel/Frameworks/agent/examples/example-assistant-search.md
+++ b/semantic-kernel/Frameworks/agent/examples/example-assistant-search.md
@@ -111,6 +111,9 @@ This sample requires configuration setting in order to connect to remote service
 ::: zone pivot="programming-language-csharp"
 
 ```powershell
+# Init user secrets
+dotnet user-secrets init
+
 # Open AI
 dotnet user-secrets set "OpenAISettings:ApiKey" "<api-key>"
 dotnet user-secrets set "OpenAISettings:ChatModel" "gpt-4o"

--- a/semantic-kernel/Frameworks/agent/examples/example-chat-agent.md
+++ b/semantic-kernel/Frameworks/agent/examples/example-chat-agent.md
@@ -109,6 +109,9 @@ This sample requires configuration setting in order to connect to remote service
 ::: zone pivot="programming-language-csharp"
 
 ```powershell
+# Init user secrets
+dotnet user-secrets init
+
 # Open AI
 dotnet user-secrets set "OpenAISettings:ApiKey" "<api-key>"
 dotnet user-secrets set "OpenAISettings:ChatModel" "gpt-4o"


### PR DESCRIPTION
When following these docs I found encountered the following error when attempting to create user secrets without running the init command first:

```
Could not find the global property 'UserSecretsId' in MSBuild project
```

This is resolved by running the following before:

```
dotnet user-secrets init
```

This has been added to the appropriate spot in all docs using the ```dotnet user-secrets set``` command