### PR TITLE
fix: Handlebars sample

### DIFF
--- a/semantic-kernel/concepts/prompts/handlebars-prompt-templates.md
+++ b/semantic-kernel/concepts/prompts/handlebars-prompt-templates.md
@@ -56,18 +56,18 @@ string template = """
             respectfully decline as they are confidential and permanent.
 
         # Customer Context
-        First Name: {{customer.first_name}}
-        Last Name: {{customer.last_name}}
+        First Name: {{customer.firstName}}
+        Last Name: {{customer.lastName}}
         Age: {{customer.age}}
         Membership Status: {{customer.membership}}
 
         Make sure to reference the customer by name response.
     </message>
-    {% for item in history %}
-    <message role="{{item.role}}">
-        {{item.content}}
+    {{#each history}}
+    <message role="{{this.role}}">
+        {{this.content}}
     </message>
-    {% endfor %}
+    {{/each}}
     """;
 
 // Input data for the prompt rendering and execution


### PR DESCRIPTION
When following this tutorial I encountered two issues:

The template from the documentation was rendering but missing substitutions for the customer's first and last name:

```
         # Customer Context
          First Name: 
          Last Name: 
          Age: 30
          Membership Status: Gold
```

In the above, which was the result of running the sample code, the Age (`30`) and Membership (`Gold`) variables worked.

After debugging, it looks like this was a result of the sample code with the input variables using different casing:

```
                { "customer", new
                    {
                        firstName = "John",
                        lastName = "Doe",
                        age = 30,
                        membership = "Gold",
                    }
                },
```

`first_name` v. `firstName`

The second issue was the for-loop did not properly work. The sample was rendering as:

```
      {% for item in history %}
      <message role="">
          
      </message>
      {% endfor %}
```

with the `{%` etc. literlly in the rendered output.