### PR TITLE
Fix Various Typos in Docs

### DIFF
--- a/semantic-kernel/Frameworks/agent/agent-architecture.md
+++ b/semantic-kernel/Frameworks/agent/agent-architecture.md
@@ -232,7 +232,7 @@ Additionally, an agent can be configured directly using a _Prompt Template Confi
 - [`prompt_template_config`](/python/api/semantic-kernel/semantic_kernel.prompt_template.prompt_template_config)
 - [`kernel_prompt_template`](/python/api/semantic-kernel/semantic_kernel.prompt_template.kernel_prompt_template)
 - [`jinja2_prompt_template`](/python/api/semantic-kernel/semantic_kernel.prompt_template.jinja2_prompt_template)
-- [`handlebars_prompt_teplate`](/python/api/semantic-kernel/semantic_kernel.prompt_template.handlebars_prompt_template)
+- [`handlebars_prompt_template`](/python/api/semantic-kernel/semantic_kernel.prompt_template.handlebars_prompt_template)
 
 ::: zone-end
 

--- a/semantic-kernel/Frameworks/agent/agent-chat.md
+++ b/semantic-kernel/Frameworks/agent/agent-chat.md
@@ -280,7 +280,7 @@ history = await chat.get_chat_messages()
 
 ::: zone-end
 
-Since different agent types or configurations may maintain their own version of the conversation history, agent specific history is also available by specifing an agent.  (For example: [`OpenAIAssistant`](./assistant-agent.md) versus [`ChatCompletionAgent`](./chat-completion-agent.md).)
+Since different agent types or configurations may maintain their own version of the conversation history, agent specific history is also available by specifying an agent.  (For example: [`OpenAIAssistant`](./assistant-agent.md) versus [`ChatCompletionAgent`](./chat-completion-agent.md).)
 
 ::: zone pivot="programming-language-csharp"
 ```csharp
@@ -470,7 +470,7 @@ chat = AgentGroupChat(
 
 In _multi-turn_ invocation, the _Termination Strategy_ dictates when the final turn takes place. This strategy ensures the conversation ends at the appropriate point.
 
-This strategy is defined by a base class that can be extended to implement custom behaviors tailored to specific needs. For convenience, serveral predefined concrete _Selection Strategies_ are also available, offering ready-to-use approaches for defining termination criteria for an `AgentChat` conversations.
+This strategy is defined by a base class that can be extended to implement custom behaviors tailored to specific needs. For convenience, several predefined concrete _Selection Strategies_ are also available, offering ready-to-use approaches for defining termination criteria for an `AgentChat` conversations.
 
 ::: zone pivot="programming-language-csharp"
 

--- a/semantic-kernel/Frameworks/agent/agent-functions.md
+++ b/semantic-kernel/Frameworks/agent/agent-functions.md
@@ -170,7 +170,7 @@ ChatCompletionAgent CreateSpecificAgent(Kernel kernel)
     agentKernel.CreateFunctionFromMethod(StatelessPlugin.AStaticMethod);
 
     // Initialize plug-in from a prompt
-    agentKernel.CreateFunctionFromPrompt("<your prompt instructiosn>");
+    agentKernel.CreateFunctionFromPrompt("<your prompt instructions>");
     
     // Create the agent
     return 

--- a/semantic-kernel/Frameworks/agent/agent-streaming.md
+++ b/semantic-kernel/Frameworks/agent/agent-streaming.md
@@ -181,7 +181,7 @@ await foreach (StreamingChatMessageContent response in chat.InvokeStreamingAsync
 {
     if (!lastAgent.Equals(response.AuthorName, StringComparison.Ordinal))
     {
-        // Process begining of agent response
+        // Process beginning of agent response
         lastAgent = response.AuthorName;
     }
 

--- a/semantic-kernel/Frameworks/agent/agent-templates.md
+++ b/semantic-kernel/Frameworks/agent/agent-templates.md
@@ -38,7 +38,7 @@ Additionally, an agent can be configured directly using a _Prompt Template Confi
 - [`prompt_template_config`](/python/api/semantic-kernel/semantic_kernel.prompt_template.prompt_template_config)
 - [`kernel_prompt_template`](/python/api/semantic-kernel/semantic_kernel.prompt_template.kernel_prompt_template)
 - [`jinja2_prompt_template`](/python/api/semantic-kernel/semantic_kernel.prompt_template.jinja2_prompt_template)
-- [`handlebars_prompt_teplate`](/python/api/semantic-kernel/semantic_kernel.prompt_template.handlebars_prompt_template)
+- [`handlebars_prompt_template`](/python/api/semantic-kernel/semantic_kernel.prompt_template.handlebars_prompt_template)
 
 ::: zone-end
 
@@ -284,7 +284,7 @@ async for response in agent.invoke(chat, arguments=override_arguments):
 
 ## How-To
 
-For an end-to-end example for creating an agent from a _pmompt-template_, see:
+For an end-to-end example for creating an agent from a _prompt-template_, see:
 
 - [How-To: `ChatCompletionAgent`](./examples/example-chat-agent.md)
 

--- a/semantic-kernel/Frameworks/agent/chat-completion-agent.md
+++ b/semantic-kernel/Frameworks/agent/chat-completion-agent.md
@@ -124,7 +124,7 @@ agent = ChatCompletionAgent(
 
 ## AI Service Selection
 
-No different from using _Semantic Kernel_ [AI services](../../concepts/ai-services/index.md) directly, a `ChatCompletionAgent` supports the specification of a _service-selector_.  A _service-selector_ indentifies which [AI service](../../concepts/ai-services/index.md) to target when the [`Kernel`](../../concepts/kernel.md) contains more than one.
+No different from using _Semantic Kernel_ [AI services](../../concepts/ai-services/index.md) directly, a `ChatCompletionAgent` supports the specification of a _service-selector_.  A _service-selector_ identifies which [AI service](../../concepts/ai-services/index.md) to target when the [`Kernel`](../../concepts/kernel.md) contains more than one.
 
 > Note: If multiple [AI services](../../concepts/ai-services/index.md) are present and no _service-selector_ is provided, the same _default_ logic is applied for the agent that you'd find when using an [AI services](../../concepts/ai-services/index.md) outside of the `Agent Framework`
 

--- a/semantic-kernel/Frameworks/agent/examples/example-agent-collaboration.md
+++ b/semantic-kernel/Frameworks/agent/examples/example-agent-collaboration.md
@@ -15,7 +15,7 @@ ms.service: semantic-kernel
 
 ## Overview
 
-In this sample, we will explore how to use `AgentGroupChat` to coordinate collboration of two different agents working to review and rewrite user provided content.  Each agent is assigned a distinct role:
+In this sample, we will explore how to use `AgentGroupChat` to coordinate collaboration of two different agents working to review and rewrite user provided content.  Each agent is assigned a distinct role:
 
 - **Reviewer**: Reviews and provides direction to _Writer_.
 - **Writer**: Updates user content based on _Reviewer_ input.
@@ -251,7 +251,7 @@ kernel = Kernel()
 ::: zone-end
 
 ::: zone pivot="programming-language-csharp"
-Let's also create a second `Kernel` instance via _cloning_ and add a plug-in that will allow the reivew to place updated content on the clip-board.
+Let's also create a second `Kernel` instance via _cloning_ and add a plug-in that will allow the review to place updated content on the clip-board.
 
 ```csharp
 Kernel toolKernel = kernel.Clone();
@@ -342,7 +342,7 @@ ChatCompletionAgent agentReviewer =
         Name = ReviewerName,
         Instructions =
             """
-            Your responsiblity is to review and identify how to improve user provided content.
+            Your responsibility is to review and identify how to improve user provided content.
             If the user has providing input or direction for content already provided, specify how to address this input.
             Never directly perform the correction or provide example.
             Once the content has been updated in a subsequent response, you will review the content again until satisfactory.
@@ -443,7 +443,7 @@ The first to reason over `Agent` selection:
 
 ::: zone pivot="programming-language-csharp"
 
-Using `AgentGroupChat.CreatePromptFunctionForStrategy` provides a convenient mechanism to avoid _HTML encoding_ the message paramter.
+Using `AgentGroupChat.CreatePromptFunctionForStrategy` provides a convenient mechanism to avoid _HTML encoding_ the message parameter.
 
 ```csharp
 KernelFunction selectionFunction =
@@ -713,7 +713,7 @@ if (input.Equals("EXIT", StringComparison.OrdinalIgnoreCase))
 if (input.Equals("RESET", StringComparison.OrdinalIgnoreCase))
 {
     await chat.ResetAsync();
-    Console.WriteLine("[Converation has been reset]");
+    Console.WriteLine("[Conversation has been reset]");
     continue;
 }
 
@@ -791,7 +791,7 @@ await chat.add_chat_message(message=user_input)
 
 ::: zone-end
 
-To initate the `Agent` collaboration in response to user input and display the `Agent` responses, invoke the `AgentGroupChat`; however, first be sure to reset the _Completion_ state from any prior invocation.
+To initiate the `Agent` collaboration in response to user input and display the `Agent` responses, invoke the `AgentGroupChat`; however, first be sure to reset the _Completion_ state from any prior invocation.
 
 > Note: Service failures are being caught and displayed to avoid crashing the conversation loop.
 
@@ -855,7 +855,7 @@ Try using these suggested inputs:
 1. Hi
 2. {"message: "hello world"}
 3. {"message": "hello world"}
-4. Semantic Kernel (SK) is an open-source SDK that enables developers to build and orchestrate complex AI workflows that involve natural language processing (NLP) and machine learning models. It provies a flexible platform for integrating AI capabilities such as semantic search, text summarization, and dialogue systems into applications. With SK, you can easily combine different AI services and models, define their relationships, and orchestrate interactions between them.
+4. Semantic Kernel (SK) is an open-source SDK that enables developers to build and orchestrate complex AI workflows that involve natural language processing (NLP) and machine learning models. It provides a flexible platform for integrating AI capabilities such as semantic search, text summarization, and dialogue systems into applications. With SK, you can easily combine different AI services and models, define their relationships, and orchestrate interactions between them.
 5. make this two paragraphs
 6. thank you
 7. @.\WomensSuffrage.txt
@@ -912,7 +912,7 @@ public static class Program
                 Name = ReviewerName,
                 Instructions =
                     """
-                    Your responsiblity is to review and identify how to improve user provided content.
+                    Your responsibility is to review and identify how to improve user provided content.
                     If the user has providing input or direction for content already provided, specify how to address this input.
                     Never directly perform the correction or provide example.
                     Once the content has been updated in a subsequent response, you will review the content again until satisfactory.
@@ -933,7 +933,7 @@ public static class Program
                 Name = WriterName,
                 Instructions =
                     """
-                    Your sole responsiblity is to rewrite content according to review suggestions.
+                    Your sole responsibility is to rewrite content according to review suggestions.
 
                     - Always apply all review direction.
                     - Always revise the content in its entirety without explanation.
@@ -1036,7 +1036,7 @@ public static class Program
             if (input.Equals("RESET", StringComparison.OrdinalIgnoreCase))
             {
                 await chat.ResetAsync();
-                Console.WriteLine("[Converation has been reset]");
+                Console.WriteLine("[Conversation has been reset]");
                 continue;
             }
 
@@ -1121,7 +1121,7 @@ Bringing all the steps together, we now have the final code for this example. Th
 You can try using one of the suggested inputs. As the agent chat begins, the agents will exchange messages for several iterations until the reviewer agent is satisfied with the copywriter's work. The `while` loop ensures the conversation continues, even if the chat is initially considered complete, by resetting the `is_complete` flag to `False`.
 
 1. Rozes are red, violetz are blue.
-2. Semantic Kernel (SK) is an open-source SDK that enables developers to build and orchestrate complex AI workflows that involve natural language processing (NLP) and machine learning models. It provies a flexible platform for integrating AI capabilities such as semantic search, text summarization, and dialogue systems into applications. With SK, you can easily combine different AI services and models, define their relationships, and orchestrate interactions between them.
+2. Semantic Kernel (SK) is an open-source SDK that enables developers to build and orchestrate complex AI workflows that involve natural language processing (NLP) and machine learning models. It provides a flexible platform for integrating AI capabilities such as semantic search, text summarization, and dialogue systems into applications. With SK, you can easily combine different AI services and models, define their relationships, and orchestrate interactions between them.
 4. Make this two paragraphs
 5. thank you
 7. @WomensSuffrage.txt

--- a/semantic-kernel/Frameworks/agent/examples/example-assistant-search.md
+++ b/semantic-kernel/Frameworks/agent/examples/example-assistant-search.md
@@ -411,7 +411,7 @@ try
     bool isComplete = false;
     do
     {
-        // Processing occurrs here
+        // Processing occurs here
     } while (!isComplete);
 }
 finally
@@ -454,7 +454,7 @@ finally:
 
 ::: zone-end
 
-Now let's capture user input within the previous loop.  In this case, empty input will be ignored and the term `EXIT` will signal that the conversation is completed.  Valid nput will be added to the _Assistant Thread_ as a _User_ message.
+Now let's capture user input within the previous loop.  In this case, empty input will be ignored and the term `EXIT` will signal that the conversation is completed.  Valid input will be added to the _Assistant Thread_ as a _User_ message.
 
 ::: zone pivot="programming-language-csharp"
 ```csharp

--- a/semantic-kernel/Frameworks/agent/index.md
+++ b/semantic-kernel/Frameworks/agent/index.md
@@ -56,7 +56,7 @@ Installing the _Agent Framework SDK_ is specific to the distribution channel ass
 
 ::: zone pivot="programming-language-csharp"
 
-For .NET SDK, serveral NuGet packages are available.  
+For .NET SDK, several NuGet packages are available.  
 
 > Note: The core _Semantic Kernel SDK_ is required in addition to any agent packages.
 

--- a/semantic-kernel/concepts/ai-services/embedding-generation/index.md
+++ b/semantic-kernel/concepts/ai-services/embedding-generation/index.md
@@ -11,7 +11,7 @@ ms.service: semantic-kernel
 
 # Text Embedding generation in Semantic Kernel
 
-With text embedding generation, you can use an AI model to generate vectors (aka embeddings). These vectors encode the semantic meaning of the text in such a way that mathematical equations can be used on two vectors to compare the similiarty of the original text.
+With text embedding generation, you can use an AI model to generate vectors (aka embeddings). These vectors encode the semantic meaning of the text in such a way that mathematical equations can be used on two vectors to compare the similarity of the original text.
 This is useful for scenarios such as Retrieval Augmented Generation (RAG), where we want to search a database of information for text related to a user query.
 Any matching information can then be provided as input to Chat Completion, so that the AI Model has more context when answering the user query.
 

--- a/semantic-kernel/concepts/plugins/adding-openapi-plugins.md
+++ b/semantic-kernel/concepts/plugins/adding-openapi-plugins.md
@@ -667,7 +667,7 @@ static async Task AuthenticateRequestAsyncCallbackAsync(HttpRequestMessage reque
                 (RestApiSecurityScheme scheme, IList<string> scopes) = apiKeySchemes.First();
 
                 // Get the API key for the scheme and scopes from your app identity provider
-                var apiKey = await this.identityPropvider.GetApiKeyAsync(scheme, scopes);
+                var apiKey = await this.identityProvider.GetApiKeyAsync(scheme, scopes);
 
                 // Add the API key to the request headers
                 if (scheme.In == RestApiParameterLocation.Header)

--- a/semantic-kernel/concepts/prompts/prompt-injection-attacks.md
+++ b/semantic-kernel/concepts/prompts/prompt-injection-attacks.md
@@ -86,7 +86,7 @@ This article details the options for developers to control message tag injection
 
 ## How We Protect Against Prompt Injection Attacks
 
-In line with Microsofts security strategy we are adopting a zero trust approach and will treat content that is being inserted into prompts as being unsafe by default.
+In line with Microsoft's security strategy we are adopting a zero trust approach and will treat content that is being inserted into prompts as being unsafe by default.
 
 We used in following decision drivers to guide the design of our approach to defending against prompt injection attacks:
 
@@ -240,7 +240,7 @@ To trust the return value from a function call the pattern is very similar to tr
 
 Note: This approach will be replaced in the future by the ability to trust specific functions.
 
-The following code sample is an example where the trsutedMessageFunction and trsutedContentFunction functions return unsafe content but in this case it is trusted.
+The following code sample is an example where the `trustedMessageFunction` and `trustedContentFunction` functions return unsafe content but in this case it is trusted.
 
 ```csharp
 KernelFunction trustedMessageFunction = KernelFunctionFactory.CreateFromMethod(() => "<message role=\"system\">You are a helpful assistant who knows all about cities in the USA</message>", "TrustedMessageFunction");

--- a/semantic-kernel/concepts/vector-store-connectors/code-samples.md
+++ b/semantic-kernel/concepts/vector-store-connectors/code-samples.md
@@ -64,7 +64,7 @@ when doing a vector search.
 ## Vector search with paging
 
 When doing vector search with the Vector Store abstractions it's possible to use Top and Skip parameters to support paging, where e.g.
-you need to build a service that reponds with a small set of results per request.
+you need to build a service that responds with a small set of results per request.
 
 - [Vector search with paging](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/VectorStore_VectorSearch_Paging.cs)
 
@@ -84,10 +84,10 @@ This example shows how you can create a vector store using a custom model and re
 
 ## Using collections that were created and ingested using Langchain
 
-It's possible to use the Vector Store abstractions to access collections that were created and ingested using a different sytem, e.g. Langchain.
+It's possible to use the Vector Store abstractions to access collections that were created and ingested using a different system, e.g. Langchain.
 There are various approaches that can be followed to make the interop work correctly. E.g.
 
-1. Creating a data model that matches the storage schema that the Langchain implemenation used.
+1. Creating a data model that matches the storage schema that the Langchain implementation used.
 1. Using a custom mapper to map between the storage schema and data model.
 1. Using a record definition with special storage property names for fields.
 
@@ -95,7 +95,7 @@ In the following sample, we show how to use these approaches to construct Langch
 
 - [VectorStore Langchain Interop](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/VectorStore_Langchain_Interop.cs)
 
-For each vector store, there is a factory class that shows how to contruct the Langchain compatible Vector Store. See e.g.
+For each vector store, there is a factory class that shows how to construct the Langchain compatible Vector Store. See e.g.
 
 - [AzureAISearchFactory](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/AzureAISearchFactory.cs)
 - [PineconeFactory](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/samples/Concepts/Memory/VectorStoreLangchainInterop/PineconeFactory.cs)

--- a/semantic-kernel/concepts/vector-store-connectors/defining-your-data-model.md
+++ b/semantic-kernel/concepts/vector-store-connectors/defining-your-data-model.md
@@ -123,7 +123,7 @@ All methods to upsert or get records use a class and a vector store record defin
 This can be done by defining your own class with annotations for the fields, or by using a class/type in combination with a record definition. Two things need to be done for a class, the first is to add the annotations with the field types, the second is to decorate the class with the `vectorstoremodel` decorator.
 
 > [!TIP]
-> For the alternative approach using a record definition, refer to [definining your schema with a record definition](./schema-with-record-definition.md).
+> For the alternative approach using a record definition, refer to [defining your schema with a record definition](./schema-with-record-definition.md).
 
 Here is an example of a model that is decorated with these annotations.
 

--- a/semantic-kernel/concepts/vector-store-connectors/how-to/build-your-own-connector.md
+++ b/semantic-kernel/concepts/vector-store-connectors/how-to/build-your-own-connector.md
@@ -67,7 +67,7 @@ E.g.
 - MyDbVectorStore : IVectorStore
 - MyDbVectorStoreRecordCollection<TKey, TRecord\> : IVectorStoreRecordCollection\<TKey, TRecord\>
 
-The `VectorStoreRecordCollection` implementation should accept the name of the collection as a construtor parameter
+The `VectorStoreRecordCollection` implementation should accept the name of the collection as a constructor parameter
 and each instance of it is therefore tied to a specific collection instance in the database.
 
 Here follows specific requirements for individual methods on these interfaces.
@@ -175,7 +175,7 @@ The user should be able to provide a `VectorStoreRecordDefinition` to the
 These are specified via string based settings, but where available a connector should expect
 the strings that are provided as string consts on `Microsoft.Extensions.VectorData.IndexKind`
 and `Microsoft.Extensions.VectorData.DistanceFunction`. Where the connector requires
-index kinds and distance functions that are not available on the abovementioned static classes
+index kinds and distance functions that are not available on the above mentioned static classes
 additional custom strings may be accepted.
 
 E.g. the goal is for a user to be able to specify a standard distance function, like `DotProductSimilarity`
@@ -221,9 +221,9 @@ Let's consider each scenario.
 
 ### 6. Storage property naming
 
-The naming conventions used for properties in code doesn't always match the prefered naming
+The naming conventions used for properties in code doesn't always match the preferred naming
 for matching fields in a database.
-It is therefore valueable to support customized storage names for properties.
+It is therefore valuable to support customized storage names for properties.
 Some databases may support storage formats that already have their own mechanism for
 specifying storage names, e.g. when using JSON as the storage format you can use
 a `JsonPropertyNameAttribute` to provide a custom name.
@@ -317,7 +317,7 @@ To allow customization of these settings when using `IVectorStore.GetCollection`
 that each connector supports an optional `VectorStoreRecordCollectionFactory` that can be passed to the concrete
 implementation of `IVectorStore` as an option. Each connector should therefore provide an interface, similar to the
 following sample. If a user passes an implementation of this to the `VectorStore` as an option, this
-can be used by the `IVectorStore.GetCollection` method to consruct the `IVectorStoreRecordCollection` instance.
+can be used by the `IVectorStore.GetCollection` method to construct the `IVectorStoreRecordCollection` instance.
 
 ```csharp
 public sealed class MyDBVectorStore : IVectorStore

--- a/semantic-kernel/concepts/vector-store-connectors/how-to/vector-store-custom-mapper.md
+++ b/semantic-kernel/concepts/vector-store-connectors/how-to/vector-store-custom-mapper.md
@@ -55,7 +55,7 @@ If you want to do custom mapping, and you want to use multiple connector types, 
 Our first step is to create a data model. In this case we will not annotate the data model with attributes, since we will provide a separate record definition
 that describes what the database schema will look like.
 
-Also note that this model is complex, with seperate classes for vectors and additional product info.
+Also note that this model is complex, with separate classes for vectors and additional product info.
 
 ```csharp
 public class Product

--- a/semantic-kernel/concepts/vector-store-connectors/how-to/vector-store-data-ingestion.md
+++ b/semantic-kernel/concepts/vector-store-connectors/how-to/vector-store-data-ingestion.md
@@ -36,7 +36,7 @@ you can easily start a Redis container using docker.
 docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
 ```
 
-To verify that it is running succesfully, visit [http://localhost:8001/redis-stack/browser](http://localhost:8001/redis-stack/browser) in your browser.
+To verify that it is running successfully, visit [http://localhost:8001/redis-stack/browser](http://localhost:8001/redis-stack/browser) in your browser.
 
 The rest of these instructions will assume that you are using this container using the above settings.
 

--- a/semantic-kernel/concepts/vector-store-connectors/memory-stores.md
+++ b/semantic-kernel/concepts/vector-store-connectors/memory-stores.md
@@ -17,7 +17,7 @@ Semantic Kernel provides a set of Memory Store abstractions where the primary in
 
 ## Memory Store vs Vector Store abstractions
 
-As part of an effort to evolve and expand the vector storage and search capbilities of Semantic Kernel, we have released a new set of abstractions to replace the Memory Store abstractions.
+As part of an effort to evolve and expand the vector storage and search capabilities of Semantic Kernel, we have released a new set of abstractions to replace the Memory Store abstractions.
 We are calling the replacement abstractions Vector Store abstractions.
 The purpose of both are similar, but their interfaces differ and the Vector Store abstractions provide expanded functionality.
 
@@ -70,7 +70,7 @@ Semantic Kernel offers several Memory Store connectors to vector databases that 
 
 ## Migrating from Memory Stores to Vector Stores
 
-If you wanted to migrate from using the Memory Store abstractions to the Vector Store abtractions there are various ways in which you can do this.
+If you wanted to migrate from using the Memory Store abstractions to the Vector Store abstractions there are various ways in which you can do this.
 
 ### Use the existing collection with the Vector Store abstractions
 

--- a/semantic-kernel/concepts/vector-store-connectors/out-of-the-box-connectors/elasticsearch-connector.md
+++ b/semantic-kernel/concepts/vector-store-connectors/out-of-the-box-connectors/elasticsearch-connector.md
@@ -21,7 +21,7 @@ The Elasticsearch Vector Store connector can be used to access and manage data i
 |-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | Collection maps to                | Elasticsearch index                                                                                                              |
 | Supported key property types      | string                                                                                                                           |
-| Supported data property types     | All types that are supported by System.Text.Json (etiher built-in or by using a custom converter)                                |
+| Supported data property types     | All types that are supported by System.Text.Json (either built-in or by using a custom converter)                                |
 | Supported vector property types   | <ul><li>ReadOnlyMemory\<float\></li><li>IEnumerable\<float\></li></ul>                                                           |
 | Supported index types             | <ul><li>HNSW (32, 8, or 4 bit)</li><li>FLAT (32, 8, or 4 bit)</li></ul>                                                          |
 | Supported distance functions      | <ul><li>CosineSimilarity</li><li>DotProductSimilarity</li><li>EuclideanDistance</li><li>MaxInnerProduct</li></ul>                |

--- a/semantic-kernel/support/index.md
+++ b/semantic-kernel/support/index.md
@@ -15,7 +15,7 @@ ms.service: semantic-kernel
 | Your preference | What's available |
 |---|---|
 | Read the docs | [This learning site](/semantic-kernel/overview) is the home of the latest information for developers |
-| Visit the repo | Our open-source [GitHub repository](https://github.com/microsoft/semantic-kernel) is availble for perusal and suggestions |
+| Visit the repo | Our open-source [GitHub repository](https://github.com/microsoft/semantic-kernel) is available for perusal and suggestions |
 | Connect with the Semantic Kernel Team | Visit our [GitHub Discussions](https://github.com/microsoft/semantic-kernel/discussions) to get supported quickly with our [CoC](/semantic-kernel/support/CodeofConduct) actively enforced | 
 |  Office Hours | We will be hosting regular office hours; the calendar invites and cadence are located here: [Community.MD](https://github.com/microsoft/semantic-kernel/blob/main/COMMUNITY.md) |
 

--- a/semantic-kernel/support/migration/v1-migration-guide.md
+++ b/semantic-kernel/support/migration/v1-migration-guide.md
@@ -105,7 +105,7 @@ Many of our internal naming conventions were changed to better reflect how the A
 
 ## Code Name Changes
 
-Following the convetion name changes, many of the code names were also changed to better reflect the new naming conventions. Abbreaviations were also removed to make the code more readable.
+Following the convention name changes, many of the code names were also changed to better reflect the new naming conventions. Abbreviations were also removed to make the code more readable.
 
 | Previous Name                               | V1 Name                                |
 | ------------------------------------------- | -------------------------------------- |
@@ -252,7 +252,7 @@ Many changes were made to our KernelBuilder to make it more intuitive and easier
 
 - Creating a `KernelBuilder` can now be only created using the `Kernel.CreateBuilder()` method.
 
-  This change make it simpler and easier to use the KernelBuilder in any code-base ensureing one main way of using the builder instead of multiple ways that adds complexity and maintenance overhead.
+  This change make it simpler and easier to use the KernelBuilder in any code-base ensuring one main way of using the builder instead of multiple ways that adds complexity and maintenance overhead.
 
   ```csharp
   // Before
@@ -288,7 +288,7 @@ As the Kernel became just a container for the plugins and now executes just one 
 
 ## SKContext
 
-After a lot of discussions and feedback internally and from the community, to simplify the API and make it more intuitive, the `SKContext` concept was dilluted in different entities: `KernelArguments` for function inputs and `FunctionResult` for function outputs.
+After a lot of discussions and feedback internally and from the community, to simplify the API and make it more intuitive, the `SKContext` concept was diluted in different entities: `KernelArguments` for function inputs and `FunctionResult` for function outputs.
 
 With the important decision to make `Kernel` a required argument of a function calling, the `SKContext` was removed and the `KernelArguments` and `FunctionResult` were introduced.
 


### PR DESCRIPTION
This pull request addresses several spelling and typographical errors across various documentation files in the `semantic-kernel` project. The corrections ensure clarity and accuracy in the documentation.

### Spelling and Typographical Corrections:

* [`semantic-kernel/Frameworks/agent/agent-architecture.md`](diffhunk://#diff-ce8aa5a9f1847a55bf5361e660dcfa2ff85c24c8355b060df4ddd5e0576b3c48L235-R235): Corrected the spelling of "handlebars_prompt_template".
* [`semantic-kernel/Frameworks/agent/agent-chat.md`](diffhunk://#diff-72c754843c4e8d74a5338dc75fc5401e2540dca0356e214b64bc77707fbdfc45L283-R283): Corrected the spelling of "specifying" and "several". [[1]](diffhunk://#diff-72c754843c4e8d74a5338dc75fc5401e2540dca0356e214b64bc77707fbdfc45L283-R283) [[2]](diffhunk://#diff-72c754843c4e8d74a5338dc75fc5401e2540dca0356e214b64bc77707fbdfc45L473-R473)
* [`semantic-kernel/Frameworks/agent/agent-functions.md`](diffhunk://#diff-473d25f3d4a4e55e73d53fab1fe2ee2ac09345b40e821561213d4280a2c67b40L173-R173): Corrected the spelling of "instructions".
* [`semantic-kernel/Frameworks/agent/agent-streaming.md`](diffhunk://#diff-b2cdaa02f5b7e693d96a7c5bce836f0a213c315e28c95956eb013a844ff2a7b9L184-R184): Corrected the spelling of "beginning".
* [`semantic-kernel/Frameworks/agent/agent-templates.md`](diffhunk://#diff-c0631eab2b4f133104bb60bfa34581bbdb3ac3b8350b231ed4aad307c5227cd5L41-R41): Corrected the spelling of "handlebars_prompt_template" and "prompt-template". [[1]](diffhunk://#diff-c0631eab2b4f133104bb60bfa34581bbdb3ac3b8350b231ed4aad307c5227cd5L41-R41) [[2]](diffhunk://#diff-c0631eab2b4f133104bb60bfa34581bbdb3ac3b8350b231ed4aad307c5227cd5L287-R287)
* [`semantic-kernel/Frameworks/agent/chat-completion-agent.md`](diffhunk://#diff-4ae346c25a7671c54430d5da0605c941740a84e64b90f7cdba494b70ae9951faL127-R127): Corrected the spelling of "identifies".
* [`semantic-kernel/Frameworks/agent/examples/example-agent-collaboration.md`](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L18-R18): Corrected multiple spelling errors including "collaboration", "responsibility", "parameter", "conversation", "initiate", and "provides". [[1]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L18-R18) [[2]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L254-R254) [[3]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L345-R345) [[4]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L446-R446) [[5]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L716-R716) [[6]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L794-R794) [[7]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L858-R858) [[8]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L915-R915) [[9]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L936-R936) [[10]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L1039-R1039) [[11]](diffhunk://#diff-b771665bafffaea88f4ec139a7e8a9f1c6bc1868b0cfbc7016c3dea74612ecb0L1124-R1124)
* [`semantic-kernel/Frameworks/agent/examples/example-assistant-search.md`](diffhunk://#diff-c2b208eadd3eae456e56dfaaa531b1cd143cf58ebebd658faecac41ba3e74189L414-R414): Corrected the spelling of "occurs" and "input". [[1]](diffhunk://#diff-c2b208eadd3eae456e56dfaaa531b1cd143cf58ebebd658faecac41ba3e74189L414-R414) [[2]](diffhunk://#diff-c2b208eadd3eae456e56dfaaa531b1cd143cf58ebebd658faecac41ba3e74189L457-R457)
* [`semantic-kernel/Frameworks/agent/index.md`](diffhunk://#diff-eb645a5cdb1f1423cd6b8d82fdb691a0fa4d29705b80ed1fbf29164cb89ace79L59-R59): Corrected the spelling of "several".
* [`semantic-kernel/concepts/ai-services/embedding-generation/index.md`](diffhunk://#diff-28bf3856ce9a0ad07c0e44ffd304c5f906bcffad86c5f0655c9a1f5e1e3595a4L14-R14): Corrected the spelling of "similarity".
* [`semantic-kernel/concepts/plugins/adding-openapi-plugins.md`](diffhunk://#diff-266b20a5554a9a9f662e2de096937d49a0417f405b161466c90732f888b1ac0fL670-R670): Corrected the spelling of "identityProvider".
* [`semantic-kernel/concepts/prompts/prompt-injection-attacks.md`](diffhunk://#diff-657adfdee3c00e123efc532e1df19ea6d7930d1ffed587a7b0b8682292ae4e5eL89-R89): Corrected the spelling of "Microsoft's".