### PR TITLE
Update chat-history.md

### DIFF
--- a/semantic-kernel/concepts/ai-services/chat-completion/chat-history.md
+++ b/semantic-kernel/concepts/ai-services/chat-completion/chat-history.md
@@ -234,7 +234,7 @@ chatHistory.Add(
             new FunctionResultContent(
                 functionName: "get_user_allergies",
                 pluginName: "User",
-                id: "0001",
+                callId: "0001",
                 result: "{ \"allergies\": [\"peanuts\", \"gluten\"] }"
             )
         ]
@@ -247,7 +247,7 @@ chatHistory.Add(
             new FunctionResultContent(
                 functionName: "get_user_allergies",
                 pluginName: "User",
-                id: "0002",
+                callId: "0002",
                 result: "{ \"allergies\": [\"dairy\", \"soy\"] }"
             )
         ]


### PR DESCRIPTION
`FunctionResultContent` from `1.40.1` has `callId` instead of just `id`.