### PR TITLE
Add Go language support to Agent Framework docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ This repository contains documentation for two separate Microsoft products, publ
 | Docset | Languages | Source Code | Published URL |
 |--------|-----------|-------------|---------------|
 | **Semantic Kernel** (`semantic-kernel/`) | C#, Python, Java | [microsoft/semantic-kernel](https://github.com/microsoft/semantic-kernel) | [/semantic-kernel](https://learn.microsoft.com/semantic-kernel) |
-| **Agent Framework** (`agent-framework/`) | C#, Python | [microsoft/agent-framework](https://github.com/microsoft/agent-framework) | [/agent-framework](https://learn.microsoft.com/agent-framework) |
+| **Agent Framework** (`agent-framework/`) | C#, Python, Go | [microsoft/agent-framework](https://github.com/microsoft/agent-framework), [microsoft/agent-framework-go](https://github.com/microsoft/agent-framework-go) | [/agent-framework](https://learn.microsoft.com/agent-framework) |
 
 Each docset is independent with its own `docfx.json`, `TOC.yml`, and `zone-pivot-groups.yml`.
 
@@ -47,7 +47,7 @@ Java content here
 ::: zone-end
 ```
 
-**Agent Framework** (C#, Python only - no Java):
+**Agent Framework** (C#, Python, Go):
 ```markdown
 ::: zone pivot="programming-language-csharp"
 C# content here
@@ -55,6 +55,10 @@ C# content here
 
 ::: zone pivot="programming-language-python"
 Python content here
+::: zone-end
+
+::: zone pivot="programming-language-go"
+Go content here
 ::: zone-end
 ```
 
@@ -69,6 +73,8 @@ Reference code from external sample repositories using DocFX syntax:
 Sample repositories (configured in `.openpublishing.publish.config.json`):
 - `semantic-kernel-samples` → [microsoft/semantic-kernel](https://github.com/microsoft/semantic-kernel) (main branch)
 - `semantic-kernel-samples-java` → [microsoft/semantic-kernel-java](https://github.com/microsoft/semantic-kernel-java)
+- `agent-framework-code` → [microsoft/agent-framework](https://github.com/microsoft/agent-framework) (main branch)
+- `agent-framework-go` → [microsoft/agent-framework-go](https://github.com/microsoft/agent-framework-go) (main branch)
 
 ### Table of Contents
 

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -74,6 +74,12 @@
       "url": "https://github.com/microsoft/agent-framework",
       "branch": "main",
       "branch_mapping": {}
+    },
+    {
+      "path_to_root": "agent-framework-go",
+      "url": "https://github.com/microsoft/agent-framework-go",
+      "branch": "main",
+      "branch_mapping": {}
     }
   ],
   "branch_target_mapping": {

--- a/agent-framework/agents/agent-pipeline.md
+++ b/agent-framework/agents/agent-pipeline.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: conceptual
 ms.author: edvan
-ms.date: 04/02/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -290,6 +290,45 @@ Even so, Python `GitHubCopilotAgent` still supports agent middleware and now run
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Agent pipeline architecture
+
+In Go, agents use a layered middleware pipeline. Middlewares wrap the agent's `Run` function, each calling `next` to pass control to the next layer.
+
+### Pipeline order
+
+When an agent runs, middlewares are applied in this order:
+
+1. **Context provider middleware** — Injects context from registered `ContextProvider` instances
+2. **Custom middlewares** — Your registered middlewares, applied in declaration order
+3. **Auto-call middleware** — Automatically invokes function tools when the model requests them
+4. **Provider** — The underlying LLM provider (e.g., OpenAI, Anthropic)
+
+### Middleware interface
+
+```go
+type Middleware interface {
+    Run(next RunFunc, ctx context.Context, messages []*message.Message,
+        options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error]
+}
+```
+
+Each middleware receives the `next` function in the chain and can:
+- Modify messages or options before calling `next`
+- Process or transform the response after calling `next`
+- Short-circuit the pipeline by returning without calling `next`
+
+### Built-in middlewares
+
+| Middleware | Package | Purpose |
+|---|---|---|
+| Auto-call | `middleware/autocall` | Automatically invokes function tools |
+| Context provider | `middleware/contextprovider` | Injects context from providers |
+| OpenTelemetry | `middleware/otel` | Traces agent invocations |
+| Structured output | `middleware/structuredoutput` | Handles structured output parsing |
+| Logger | `middleware/logger` | Logs agent interactions |
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/background-responses.md
+++ b/agent-framework/agents/background-responses.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: sergeymenshykh
 ms.topic: reference
 ms.author: semenshi
-ms.date: 03/13/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -253,6 +253,21 @@ if last_token is not None:
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Background responses
+
+Go agents support background responses through the `agentopt.AllowBackgroundResponses` option. This enables the agent to produce asynchronous responses that can be retrieved later.
+
+```go
+resp, err := a.RunText(ctx, "Start a long analysis.",
+    agentopt.Session(session),
+    agentopt.AllowBackgroundResponses(true),
+).Collect()
+```
+
+Background responses require an explicit session via `agentopt.Session(session)` to ensure consistent behavior between initial and follow-up runs.
+
+::: zone-end
 ## Best Practices
 
 When working with background responses, consider the following best practices:

--- a/agent-framework/agents/conversations/compaction.md
+++ b/agent-framework/agents/conversations/compaction.md
@@ -647,6 +647,12 @@ compacted = await apply_compaction(
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/conversations/context-providers.md
+++ b/agent-framework/agents/conversations/context-providers.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: conceptual
 ms.author: edvan
-ms.date: 02/13/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -382,6 +382,67 @@ class DatabaseHistoryProvider(HistoryProvider):
 > audit = InMemoryHistoryProvider("audit", load_messages=False, store_context_messages=True)
 > agent = OpenAIChatClient().as_agent(context_providers=[primary, audit])
 > ```
+
+:::zone-end
+
+:::zone pivot="programming-language-go"
+## Context providers
+
+Context providers inject additional context before each agent run and persist state after each run.
+
+### Define a context provider
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/memory"
+    "github.com/microsoft/agent-framework-go/message"
+)
+
+provider := &memory.ContextProvider{
+    SourceID: "user_memory",
+    Provide: func(ctx memory.BeforeRunContext) (memory.Context, error) {
+        // Inject context before the agent runs
+        return memory.Context{
+            Messages: []*message.Message{{
+                Role:     message.RoleSystem,
+                Contents: []message.Content{&message.TextContent{Text: "User prefers short answers."}},
+            }},
+        }, nil
+    },
+    Store: func(ctx memory.AfterRunContext) error {
+        // Persist state after the agent runs
+        return nil
+    },
+}
+```
+
+### Register context providers
+
+```go
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        ContextProviders: []*memory.ContextProvider{provider},
+    },
+})
+```
+
+### Access session state in providers
+
+Context providers can read and write session state:
+
+```go
+Provide: func(ctx memory.BeforeRunContext) (memory.Context, error) {
+    var state MyState
+    ctx.Session.Get("my_key", &state)
+    // Use state to customize context...
+},
+Store: func(ctx memory.AfterRunContext) error {
+    // Extract info from response messages
+    ctx.Session.Set("my_key", updatedState)
+    return nil
+},
+```
 
 :::zone-end
 

--- a/agent-framework/agents/conversations/index.md
+++ b/agent-framework/agents/conversations/index.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: conceptual
 ms.author: edvan
-ms.date: 02/13/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -69,6 +69,43 @@ resumed = AgentSession.from_dict(serialized)
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Conversations overview
+
+The Go `memory` package provides the core types for managing conversation state:
+
+- `memory.Session` — Thread-safe key-value state container tied to a conversation
+- `memory.ContextProvider` — Injects context before runs and persists state after runs
+
+### Create a session
+
+```go
+session, err := a.CreateSession(ctx)
+if err != nil {
+    panic(err)
+}
+```
+
+### Use a session for multi-turn conversations
+
+```go
+resp, _ := a.RunText(ctx, "My name is Alice.", agentopt.Session(session)).Collect()
+resp, _ = a.RunText(ctx, "What is my name?", agentopt.Session(session)).Collect()
+```
+
+### Persist sessions
+
+Sessions can be serialized to JSON for storage and later resumed:
+
+```go
+data, err := a.MarshalSession(ctx, session)
+// store data...
+
+// later:
+session, err := a.UnmarshalSession(ctx, data)
+```
+
+:::zone-end
 ## Guide map
 
 | Page | Focus |

--- a/agent-framework/agents/conversations/session.md
+++ b/agent-framework/agents/conversations/session.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: conceptual
 ms.author: edvan
-ms.date: 02/13/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -110,6 +110,66 @@ resumed = AgentSession.from_dict(serialized)
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Sessions
+
+The `memory.Session` type provides thread-safe state management for conversations.
+
+### Create and use a session
+
+```go
+session, err := a.CreateSession(ctx)
+if err != nil {
+    panic(err)
+}
+
+// Attach the session to runs
+resp, _ := a.RunText(ctx, "Hello!", agentopt.Session(session)).Collect()
+resp, _ = a.RunText(ctx, "Follow-up question.", agentopt.Session(session)).Collect()
+```
+
+### Store and retrieve values
+
+Sessions provide typed key-value storage:
+
+```go
+type UserPrefs struct {
+    Theme    string `json:"theme"`
+    Language string `json:"language"`
+}
+
+// Store a value
+session.Set("user_prefs", UserPrefs{Theme: "dark", Language: "en"})
+
+// Retrieve a value
+var prefs UserPrefs
+session.Get("user_prefs", &prefs)
+
+// Delete a value
+session.Delete("user_prefs")
+```
+
+### Serialize sessions for persistence
+
+```go
+// Serialize to JSON
+data, err := a.MarshalSession(ctx, session)
+
+// Save to disk, database, etc.
+os.WriteFile("session.json", data, 0644)
+
+// Later, restore the session
+loaded, _ := os.ReadFile("session.json")
+resumedSession, err := a.UnmarshalSession(ctx, loaded)
+
+// Continue the conversation
+resp, _ := a.RunText(ctx, "Continue from where we left off.", agentopt.Session(resumedSession)).Collect()
+```
+
+> [!TIP]
+> See the [persisted conversation sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step06_persisted_conversation/main.go) for a complete example.
+
+:::zone-end
 > [!IMPORTANT]
 > Sessions are agent/service-specific. Reusing a session with a different agent configuration or provider can lead to invalid context.
 

--- a/agent-framework/agents/conversations/storage.md
+++ b/agent-framework/agents/conversations/storage.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: conceptual
 ms.author: edvan
-ms.date: 02/13/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -384,6 +384,44 @@ resumed = AgentSession.from_dict(serialized)
 > Use an additional audit/eval history provider (`load_messages=False`, `store_context_messages=True`) to capture enriched context plus input/output without affecting primary history loading.
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Persistent storage
+
+Sessions can be persisted through serialization. The agent provides `MarshalSession` and `UnmarshalSession` methods for this purpose.
+
+### File-based storage
+
+```go
+// Save session state
+data, err := a.MarshalSession(ctx, session)
+if err != nil {
+    panic(err)
+}
+os.WriteFile("session.json", data, 0644)
+
+// Load session state
+loaded, _ := os.ReadFile("session.json")
+session, err := a.UnmarshalSession(ctx, loaded)
+```
+
+### Custom storage backends
+
+For database-backed storage, serialize the session to `[]byte` and store it with your preferred backend:
+
+```go
+// Store in your database
+data, _ := a.MarshalSession(ctx, session)
+db.Set(sessionID, data)
+
+// Retrieve from your database
+data, _ := db.Get(sessionID)
+session, _ := a.UnmarshalSession(ctx, data)
+```
+
+> [!TIP]
+> See the [third-party session storage sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step07_3rdparty_session_storage/main.go) for a complete example.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/declarative.md
+++ b/agent-framework/agents/declarative.md
@@ -141,6 +141,12 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/index.md
+++ b/agent-framework/agents/index.md
@@ -4,7 +4,7 @@ titleSuffix: Microsoft Foundry
 description: Learn different Agent Framework agent types.
 ms.service: agent-framework
 ms.topic: tutorial
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.reviewer: ssalgado
 zone_pivot_groups: programming-languages
 author: TaoChenOSU
@@ -340,6 +340,73 @@ Agent Framework also includes protocol-backed agents, such as:
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Agent overview
+
+In Go, agents are created through provider-specific constructors that return an `*agent.Agent`. The core types are:
+
+- `agent.Agent` — The main agent type with `Run`, `RunText`, `RunMessage` methods
+- `agent.Config` — Configuration for name, instructions, tools, middleware, and context providers
+- `agent.ProviderConfig` — Provider-level configuration (run function, session management)
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/agent"
+    "github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+)
+
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: "gpt-4o-mini",
+    Config: agent.Config{
+        Name:         "MyAgent",
+        Instructions: "You are a helpful assistant.",
+        Tools:        []tool.Tool{myTool},
+        Middlewares:  []middleware.Middleware{logger},
+    },
+})
+```
+
+### Running the agent
+
+```go
+// Non-streaming
+resp, err := a.RunText(ctx, "Hello!").Collect()
+
+// Streaming
+for update, err := range a.RunText(ctx, "Hello!", agentopt.Stream(true)) {
+    // process each update
+}
+
+// With message objects
+msg := message.New(&message.TextContent{Text: "Hello!"})
+resp, err := a.RunMessage(ctx, msg).Collect()
+```
+
+### Sessions
+
+Sessions maintain conversation state across multiple turns:
+
+```go
+session, err := a.CreateSession(ctx)
+resp, _ := a.RunText(ctx, "My name is Alice.", agentopt.Session(session)).Collect()
+resp, _ = a.RunText(ctx, "What is my name?", agentopt.Session(session)).Collect()
+```
+
+### Supported providers
+
+| Provider | Package | Constructor |
+|---|---|---|
+| OpenAI Chat Completions | `openaichatagent` | `openaichatagent.New(client, config)` |
+| OpenAI Responses | `openairesponsesagent` | `openairesponsesagent.New(client, config)` |
+| Anthropic | `anthropicagent` | `anthropicagent.New(client, config)` |
+| Google Gemini | `geminiagent` | `geminiagent.New(client, config)` |
+| A2A | `a2aagent` | `a2aagent.New(client, config)` |
+| AG-UI | `aguiagent` | `aguiagent.New(client, config)` |
+
+> [!TIP]
+> See the [Go examples](https://github.com/microsoft/agent-framework-go/tree/main/examples) for complete runnable samples.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/agent-vs-run-scope.md
+++ b/agent-framework/agents/middleware/agent-vs-run-scope.md
@@ -734,6 +734,12 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/chat-middleware.md
+++ b/agent-framework/agents/middleware/chat-middleware.md
@@ -594,6 +594,12 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/defining-middleware.md
+++ b/agent-framework/agents/middleware/defining-middleware.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: dmytrostruk
 ms.topic: tutorial
 ms.author: dmytrostruk
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -737,6 +737,72 @@ if __name__ == "__main__":
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Defining middleware
+
+Middleware in Go implements the `middleware.Middleware` interface:
+
+```go
+package middleware
+
+type RunFunc = func(ctx context.Context, messages []*message.Message,
+    options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error]
+
+type Middleware interface {
+    Run(next RunFunc, ctx context.Context, messages []*message.Message,
+        options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error]
+}
+```
+
+### Using a function as middleware
+
+For simple middleware, use `middleware.Func`:
+
+```go
+import "github.com/microsoft/agent-framework-go/middleware"
+
+var loggingMiddleware = middleware.Func(
+    func(next middleware.RunFunc, ctx context.Context, messages []*message.Message,
+        options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+        log.Println("Agent invoked with", len(messages), "messages")
+        return next(ctx, messages, options...)
+    },
+)
+```
+
+### Struct-based middleware
+
+For middleware that carries state, implement the interface on a struct:
+
+```go
+type TimingMiddleware struct{}
+
+func (t *TimingMiddleware) Run(next middleware.RunFunc, ctx context.Context,
+    messages []*message.Message, options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+    start := time.Now()
+    result := next(ctx, messages, options...)
+    return func(yield func(*message.ResponseUpdate, error) bool) {
+        for update, err := range result {
+            if !yield(update, err) {
+                return
+            }
+        }
+        log.Printf("Agent run took %v", time.Since(start))
+    }
+}
+```
+
+### Chaining middleware
+
+Use `middleware.RunChain` to manually chain middlewares:
+
+```go
+result := middleware.RunChain(ctx, providerRun, []middleware.Middleware{mw1, mw2}, messages)
+```
+
+Middleware is chained in reverse order — `mw1` wraps `mw2`, which wraps the provider.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/exception-handling.md
+++ b/agent-framework/agents/middleware/exception-handling.md
@@ -250,6 +250,12 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/index.md
+++ b/agent-framework/agents/middleware/index.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: dmytrostruk
 ms.topic: reference
 ms.author: dmytrostruk
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -893,6 +893,38 @@ if __name__ == "__main__":
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Middleware overview
+
+Middleware in Go intercepts and modifies agent behavior at the run level. All middleware implements the `middleware.Middleware` interface.
+
+### Built-in middleware
+
+| Middleware | Package | Purpose |
+|---|---|---|
+| Auto-call | `middleware/autocall` | Automatically invokes function tools |
+| Context provider | `middleware/contextprovider` | Injects context from providers |
+| OpenTelemetry | `middleware/otel` | Traces agent invocations |
+| Structured output | `middleware/structuredoutput` | Handles structured output parsing |
+| Logger | `middleware/logger` | Logs agent interactions |
+
+### Registering middleware
+
+```go
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Middlewares: []middleware.Middleware{
+            otel.New(otel.Config{}),
+            myCustomMiddleware,
+        },
+    },
+})
+```
+
+Middleware is applied in the order declared — the first middleware wraps the outermost layer.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/result-overrides.md
+++ b/agent-framework/agents/middleware/result-overrides.md
@@ -520,6 +520,12 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/runtime-context.md
+++ b/agent-framework/agents/middleware/runtime-context.md
@@ -455,6 +455,12 @@ Use `function_invocation_kwargs` for tool-invocation flows and `client_kwargs` f
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/shared-state.md
+++ b/agent-framework/agents/middleware/shared-state.md
@@ -227,6 +227,12 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/middleware/termination.md
+++ b/agent-framework/agents/middleware/termination.md
@@ -479,6 +479,12 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/multimodal.md
+++ b/agent-framework/agents/multimodal.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: westey-m
 ms.topic: tutorial
 ms.author: westey
-ms.date: 09/24/2025
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -129,6 +129,40 @@ This will print the agent's analysis of the image to the console.
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Multimodal inputs
+
+Go agents support multimodal inputs through the `message` package. You can send text, images, and data content in a single message.
+
+### Send an image with a text prompt
+
+```go
+import "github.com/microsoft/agent-framework-go/message"
+
+msg := message.New(
+    &message.TextContent{Text: "What do you see in this image?"},
+    &message.URIContent{
+        URI:       "https://example.com/image.jpg",
+        MediaType: "image/jpeg",
+    },
+)
+
+resp, err := a.RunMessage(ctx, msg).Collect()
+```
+
+### Content types
+
+| Type | Description |
+|---|---|
+| `message.TextContent` | Text content |
+| `message.URIContent` | Image or file referenced by URL |
+| `message.ImageContent` | Image with base64-encoded data |
+| `message.DataContent` | Generic binary data |
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step11_using_images/main.go) for a complete runnable example.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/observability.md
+++ b/agent-framework/agents/observability.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: reference
 ms.author: edvan
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -580,6 +580,54 @@ if __name__ == "__main__":
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Observability with OpenTelemetry
+
+The Go Agent Framework includes an OpenTelemetry middleware that automatically traces agent invocations.
+
+### Setup
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/middleware/otel"
+
+    "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+    otellib "go.opentelemetry.io/otel"
+)
+
+// Create a tracer provider with a console exporter
+exporter, _ := stdouttrace.New(stdouttrace.WithPrettyPrint())
+tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
+defer tp.Shutdown(context.Background())
+otellib.SetTracerProvider(tp)
+```
+
+### Add the middleware to your agent
+
+```go
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions: "You are a helpful assistant.",
+        Middlewares: []middleware.Middleware{
+            otel.New(otel.Config{}), // OpenTelemetry tracing
+        },
+    },
+})
+```
+
+The middleware emits spans with attributes including:
+
+- `gen_ai.provider.name` — The provider name (e.g., "openai")
+- `gen_ai.agent.id` — The agent's unique ID
+- `gen_ai.agent.name` — The agent's display name
+- `gen_ai.agent.description` — The agent's description
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step08_observability/main.go) for a complete runnable example.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/anthropic.md
+++ b/agent-framework/agents/providers/anthropic.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author:  rogerbarreto
 ms.topic: tutorial
 ms.author: rbarreto
-ms.date: 12/12/2025
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -512,6 +512,57 @@ See the [Agent getting started tutorials](../../get-started/your-first-agent.md)
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Anthropic
+
+The `anthropicagent` package creates agents using the Anthropic API.
+
+### Installation
+
+```bash
+go get github.com/microsoft/agent-framework-go
+go get github.com/anthropics/anthropic-sdk-go
+```
+
+### Create an Anthropic agent
+
+```go
+import (
+    "github.com/anthropics/anthropic-sdk-go"
+    "github.com/microsoft/agent-framework-go/agent"
+    "github.com/microsoft/agent-framework-go/agent/provider/anthropicagent"
+)
+
+a := anthropicagent.New(
+    anthropic.NewClient(), // uses ANTHROPIC_API_KEY env var
+    anthropicagent.Config{
+        Model: "claude-sonnet-4-5",
+        Config: agent.Config{
+            Instructions: "You are a helpful assistant.",
+            Name:         "ClaudeAgent",
+        },
+    },
+)
+
+resp, err := a.RunText(ctx, "Tell me a joke.").Collect()
+```
+
+### Custom options
+
+Pass Anthropic-specific parameters using `anthropicagent.MessageNewParams`:
+
+```go
+resp, err := a.RunText(ctx, "Hello!",
+    anthropicagent.MessageNewParams(anthropic.MessageNewParams{
+        MaxTokens: 500,
+    }),
+).Collect()
+```
+
+> [!TIP]
+> See the [Anthropic sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/providers/anthrophic/main.go) for a complete example.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/azure-openai.md
+++ b/agent-framework/agents/providers/azure-openai.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: westey-m
 ms.topic: tutorial
 ms.author: westey
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -147,6 +147,68 @@ For more information, see the [Get Started tutorials](../../get-started/your-fir
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Azure OpenAI
+
+In Go, Azure OpenAI uses the same `openaichatagent` package as direct OpenAI, with Azure-specific client initialization.
+
+### Installation
+
+```bash
+go get github.com/microsoft/agent-framework-go
+go get github.com/openai/openai-go/v3
+go get github.com/Azure/azure-sdk-for-go/sdk/azidentity
+```
+
+### Create an Azure OpenAI agent
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    "github.com/microsoft/agent-framework-go/agent"
+    "github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+    openai "github.com/openai/openai-go/v3"
+    "github.com/openai/openai-go/v3/azure"
+)
+
+endpoint := os.Getenv("AZURE_OPENAI_ENDPOINT")
+deployment := os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+apiVersion := "2025-01-01-preview"
+
+token, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil {
+    panic(err)
+}
+
+a := openaichatagent.New(
+    openai.NewClient(
+        azure.WithEndpoint(endpoint, apiVersion),
+        azure.WithTokenCredential(token),
+    ),
+    openaichatagent.Config{
+        Model: deployment,
+        Config: agent.Config{
+            Instructions: "You are a helpful assistant.",
+            Name:         "AzureAgent",
+        },
+    },
+)
+
+resp, err := a.RunText(ctx, "Hello!").Collect()
+```
+
+### Environment variables
+
+| Variable | Description |
+|---|---|
+| `AZURE_OPENAI_ENDPOINT` | Your Azure OpenAI resource endpoint |
+| `AZURE_OPENAI_DEPLOYMENT_NAME` | The deployment/model name |
+| `AZURE_OPENAI_API_VERSION` | API version (e.g., `2025-01-01-preview`) |
+
+> [!TIP]
+> See the [Azure OpenAI sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/providers/azure/main.go) for a complete example.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/copilot-studio.md
+++ b/agent-framework/agents/providers/copilot-studio.md
@@ -92,6 +92,12 @@ async def streaming_example():
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/custom.md
+++ b/agent-framework/agents/providers/custom.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: westey-m
 ms.topic: tutorial
 ms.author: westey
-ms.date: 09/25/2025
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -411,6 +411,44 @@ For more information on how to run and interact with agents, see the [Agent gett
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Custom providers
+
+You can create a custom provider by implementing `agent.ProviderConfig` and passing it to `agent.New`:
+
+```go
+import "github.com/microsoft/agent-framework-go/agent"
+
+a := agent.New(agent.ProviderConfig{
+    Run: func(ctx context.Context, messages []*message.Message,
+        options ...agentopt.Option) iter.Seq2[*message.ResponseUpdate, error] {
+        // Your custom LLM logic here
+        return func(yield func(*message.ResponseUpdate, error) bool) {
+            yield(&message.ResponseUpdate{
+                Role: message.RoleAssistant,
+                Contents: []message.Content{
+                    &message.TextContent{Text: "Hello from custom provider!"},
+                },
+            }, nil)
+        }
+    },
+    ProviderName: "my-custom-provider",
+}, agent.Config{
+    Instructions: "You are a helpful assistant.",
+})
+```
+
+### Optional functions
+
+| Function | Purpose |
+|---|---|
+| `CreateSession` | Create a new session for the provider |
+| `MarshalSession` | Serialize session state |
+| `UnmarshalSession` | Deserialize session state |
+| `FormatOfFn` | Generate format descriptor for structured output |
+| `UnmarshalFn` | Unmarshal structured output |
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/foundry-local.md
+++ b/agent-framework/agents/providers/foundry-local.md
@@ -73,6 +73,12 @@ For additional runtime controls, `FoundryLocalClient` also supports options such
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/github-copilot.md
+++ b/agent-framework/agents/providers/github-copilot.md
@@ -408,6 +408,12 @@ For more information on how to run and interact with agents, see the [Agent gett
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/index.md
+++ b/agent-framework/agents/providers/index.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: reference
 ms.author: edvan
-ms.date: 03/25/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -71,6 +71,33 @@ Agent Framework supports many different inference services through chat clients.
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Providers overview
+
+The Go Agent Framework supports multiple LLM providers. Each provider package creates a standard `*agent.Agent` with a provider-specific constructor.
+
+| Provider | Package | Import Path |
+|---|---|---|
+| OpenAI Chat Completions | `openaichatagent` | `agent/provider/openaichatagent` |
+| OpenAI Responses | `openairesponsesagent` | `agent/provider/openairesponsesagent` |
+| Anthropic | `anthropicagent` | `agent/provider/anthropicagent` |
+| Google Gemini | `geminiagent` | `agent/provider/geminiagent` |
+| A2A | `a2aagent` | `agent/provider/a2aagent` |
+| AG-UI | `aguiagent` | `agent/provider/aguiagent` |
+
+All providers follow the same pattern:
+
+```go
+a := <provider>.New(client, <provider>.Config{
+    Model: "model-name",
+    Config: agent.Config{
+        Name:         "MyAgent",
+        Instructions: "You are a helpful assistant.",
+    },
+})
+```
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/microsoft-foundry.md
+++ b/agent-framework/agents/providers/microsoft-foundry.md
@@ -224,6 +224,12 @@ For a HostedAgent, omit `agent_version` and use the hosted agent name instead.
 Both `FoundryChatClient` and `FoundryAgent` integrate with the standard Python `Agent` experience, including tool calling, sessions, and streaming responses. For local runtimes, use the separate [Foundry Local provider page](./foundry-local.md).
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/ollama.md
+++ b/agent-framework/agents/providers/ollama.md
@@ -202,6 +202,12 @@ async def streaming_example():
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/providers/openai.md
+++ b/agent-framework/agents/providers/openai.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: westey-m
 ms.topic: tutorial
 ms.author: westey
-ms.date: 04/02/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -348,6 +348,86 @@ For more information, see the [Get Started tutorials](../../get-started/your-fir
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## OpenAI Chat Completions
+
+The `openaichatagent` package creates agents using the OpenAI Chat Completions API.
+
+### Installation
+
+```bash
+go get github.com/microsoft/agent-framework-go
+go get github.com/openai/openai-go/v3
+```
+
+### Direct OpenAI
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/agent"
+    "github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+    "github.com/openai/openai-go/v3"
+)
+
+a := openaichatagent.New(
+    openai.NewClient(), // uses OPENAI_API_KEY env var
+    openaichatagent.Config{
+        Model: "gpt-4o-mini",
+        Config: agent.Config{
+            Instructions: "You are a helpful assistant.",
+            Name:         "MyAgent",
+        },
+    },
+)
+
+resp, err := a.RunText(ctx, "Tell me a joke.").Collect()
+```
+
+### Azure OpenAI
+
+Use the same `openaichatagent` package with Azure credentials:
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+    openai "github.com/openai/openai-go/v3"
+    "github.com/openai/openai-go/v3/azure"
+)
+
+token, _ := azidentity.NewDefaultAzureCredential(nil)
+
+a := openaichatagent.New(
+    openai.NewClient(
+        azure.WithEndpoint(endpoint, apiVersion),
+        azure.WithTokenCredential(token),
+    ),
+    openaichatagent.Config{
+        Model: deployment,
+        Config: agent.Config{
+            Instructions: "You are a helpful assistant.",
+        },
+    },
+)
+```
+
+### Custom options
+
+Pass provider-specific options using `openaichatagent.ChatCompletionNewParams`:
+
+```go
+resp, err := a.RunText(ctx, "Hello!",
+    openaichatagent.ChatCompletionNewParams(openai.ChatCompletionNewParams{
+        Temperature: openai.Float(0.7),
+    }),
+).Collect()
+```
+
+**Supported tools:** Function tools, web search, local MCP tools.
+
+> [!TIP]
+> See the [OpenAI provider sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/providers/openai/main.go) and [Azure OpenAI sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/providers/azure/main.go) for complete examples.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/rag.md
+++ b/agent-framework/agents/rag.md
@@ -304,6 +304,12 @@ Each connector provides the same `create_search_function` method that can be bri
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Graph RAG
 
 For GraphRAG using graph traversal enriched search with Cypher queries, see the [Neo4j GraphRAG Provider](../integrations/neo4j-graphrag.md).

--- a/agent-framework/agents/running-agents.md
+++ b/agent-framework/agents/running-agents.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: markwallace
 ms.topic: reference
 ms.author: markwallace
-ms.date: 03/31/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -334,6 +334,87 @@ for message in response.messages:
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Streaming and non-streaming
+
+In Go, `RunText` returns a `ResponseStream` — an iterator of `(ResponseUpdate, error)` pairs.
+
+For non-streaming, call `Collect()` on the stream to gather all updates into a single response:
+
+```go
+resp, err := a.RunText(ctx, "What is the weather like in Amsterdam?").Collect()
+if err != nil {
+    panic(err)
+}
+fmt.Println(resp)
+```
+
+For streaming, iterate over the stream directly using a `range` loop:
+
+```go
+for update, err := range a.RunText(ctx, "What is the weather like in Amsterdam?", agentopt.Stream(true)) {
+    if err != nil {
+        panic(err)
+    }
+    fmt.Print(update)
+}
+```
+
+## Agent run options
+
+Options are passed as variadic `agentopt.Option` arguments. Available options include:
+
+- `agentopt.Stream(true)` — Enable streaming
+- `agentopt.Session(session)` — Attach a session for multi-turn conversations
+- `agentopt.StructuredOutput(&v)` — Request structured output into a typed value
+- `agentopt.ResponseFormat(format)` — Specify the response format
+- `agentopt.Tool(tool)` — Add a tool for this run
+- `agentopt.AllowBackgroundResponses(true)` — Enable background responses
+
+```go
+resp, err := a.RunText(ctx, "Tell me a joke.",
+    agentopt.Stream(true),
+    agentopt.Session(session),
+).Collect()
+```
+
+## Response types
+
+`ResponseStream` yields `*message.ResponseUpdate` values. Each update contains:
+
+- `Contents` — Slice of `message.Content` (text, function calls, usage, etc.)
+- `Role` — The message role (assistant, system, etc.)
+- `MessageID` / `ResponseID` — Identifiers for the message and response
+
+To get the full text result from a non-streaming response, use `Collect()`:
+
+```go
+resp, err := a.RunText(ctx, "What is the weather like in Amsterdam?").Collect()
+if err != nil {
+    panic(err)
+}
+fmt.Println(resp)
+```
+
+For streaming, process updates individually as they arrive:
+
+```go
+for update, err := range a.RunText(ctx, "Tell me a story.", agentopt.Stream(true)) {
+    if err != nil {
+        panic(err)
+    }
+    for _, c := range update.Contents {
+        if text, ok := c.(*message.TextContent); ok {
+            fmt.Print(text.Text)
+        }
+    }
+}
+```
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step01_running/main.go) for a complete runnable example.
+
+::: zone-end
 
 ## Next steps
 

--- a/agent-framework/agents/running-agents.md
+++ b/agent-framework/agents/running-agents.md
@@ -335,7 +335,6 @@ for message in response.messages:
 ::: zone-end
 
 ::: zone pivot="programming-language-go"
-## Streaming and non-streaming
 
 In Go, `RunText` returns a `ResponseStream` — an iterator of `(ResponseUpdate, error)` pairs.
 
@@ -360,8 +359,6 @@ for update, err := range a.RunText(ctx, "What is the weather like in Amsterdam?"
 }
 ```
 
-## Agent run options
-
 Options are passed as variadic `agentopt.Option` arguments. Available options include:
 
 - `agentopt.Stream(true)` — Enable streaming
@@ -377,8 +374,6 @@ resp, err := a.RunText(ctx, "Tell me a joke.",
     agentopt.Session(session),
 ).Collect()
 ```
-
-## Response types
 
 `ResponseStream` yields `*message.ResponseUpdate` values. Each update contains:
 

--- a/agent-framework/agents/skills.md
+++ b/agent-framework/agents/skills.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: SergeyMenshykh
 ms.topic: conceptual
 ms.author: semenshi
-ms.date: 03/11/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -436,6 +436,81 @@ When a script is rejected (`approved=False`), the agent is informed that the use
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Agent skills
+
+Go agents support skills through the `memory/skills` package. Skills follow a progressive disclosure pattern: advertise → load → read resources → run scripts.
+
+### File-based skills
+
+Discover skills from `SKILL.md` files on disk:
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/memory"
+    "github.com/microsoft/agent-framework-go/memory/skills"
+    "github.com/microsoft/agent-framework-go/memory/skills/fsskills"
+)
+
+skillsRoot, _ := os.OpenRoot("skills")
+defer skillsRoot.Close()
+
+skillsProvider := skills.NewContextProvider(skills.ContextProviderOptions{
+    Sources: []skills.Source{
+        fsskills.NewSourceOptions(fsskills.SourceOptions{}, skillsRoot.FS()),
+    },
+})
+
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions:     "You are a helpful assistant.",
+        ContextProviders: []*memory.ContextProvider{skillsProvider},
+    },
+})
+```
+
+### Code-defined skills
+
+Define skills entirely in Go code:
+
+```go
+skill := &skills.Skill{
+    Frontmatter: skills.Frontmatter{
+        Name:        "unit-converter",
+        Description: "Convert between common units using a multiplication factor.",
+    },
+    Content: "Use this skill when the user asks to convert between units.",
+    Resources: []skills.Resource{
+        {
+            Name:        "conversion-table",
+            Description: "Lookup table of multiplication factors.",
+            Read: func(context.Context) (any, error) {
+                return conversionTable, nil
+            },
+        },
+    },
+    Scripts: []skills.Script{
+        {
+            Name:        "convert",
+            Description: "Multiplies a value by a conversion factor.",
+            Run: func(_ context.Context, _ *skills.Skill, args map[string]any) (any, error) {
+                // perform conversion
+                return result, nil
+            },
+        },
+    },
+}
+
+provider := skills.NewContextProvider(skills.ContextProviderOptions{
+    Skills: []*skills.Skill{skill},
+})
+```
+
+> [!TIP]
+> See the [skills examples](https://github.com/microsoft/agent-framework-go/tree/main/examples/02-agents/skills) for complete runnable samples.
+
+:::zone-end
 ## Security best practices
 
 Agent Skills should be treated like any third-party code you bring into your project. Because skill instructions are injected into the agent's context — and skills can include scripts — applying the same level of review and governance you would to an open-source dependency is essential.

--- a/agent-framework/agents/structured-output.md
+++ b/agent-framework/agents/structured-output.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: westey-m
 ms.topic: tutorial
 ms.author: westey
-ms.date: 04/02/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -410,6 +410,69 @@ if __name__ == "__main__":
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Structured output
+
+Go agents support structured output through the `agentopt.StructuredOutput` option. Define a Go struct and the framework automatically generates the JSON schema and unmarshals the response.
+
+### Define the output type
+
+```go
+type PersonInfo struct {
+    Name       string `json:"name"`
+    Age        int    `json:"age"`
+    Occupation string `json:"occupation"`
+}
+```
+
+### Request structured output
+
+Use a generic helper to invoke the agent and unmarshal the response:
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/agentopt"
+)
+
+func runFor[T any](ctx context.Context, a *agent.Agent, message string, opts ...agentopt.Option) (T, error) {
+    var v T
+    opts = append(opts, agentopt.StructuredOutput(&v), agentopt.Stream(false))
+    for _, err := range a.RunText(ctx, message, opts...) {
+        if err != nil {
+            return v, err
+        }
+    }
+    return v, nil
+}
+
+person, err := runFor[PersonInfo](ctx, a,
+    "Please provide information about John Smith, who is a 35-year-old software engineer.")
+fmt.Println("Name:", person.Name)
+fmt.Println("Age:", person.Age)
+```
+
+### Specify response format at agent level
+
+You can also set the response format on the agent configuration so all runs produce structured output:
+
+```go
+import "github.com/microsoft/agent-framework-go/format/jsonformat"
+
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions: "You are a helpful assistant.",
+        RunOptions: []agentopt.Option{
+            agentopt.ResponseFormat(jsonformat.MustFor[PersonInfo]()),
+        },
+    },
+})
+```
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step05_structured_output/main.go) for a complete runnable example.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/code-interpreter.md
+++ b/agent-framework/agents/tools/code-interpreter.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: reference
 ms.author: edvan
-ms.date: 03/30/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -135,6 +135,28 @@ The current OpenAI code-interpreter sample in the code repo uses `OpenAIChatClie
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Code interpreter
+
+The `hostedtool.CodeInterpreter` type enables server-side code execution when using a provider that supports it.
+
+```go
+import "github.com/microsoft/agent-framework-go/tool/hostedtool"
+
+codeInterpreter := &hostedtool.CodeInterpreter{}
+
+a := openairesponsesagent.New(client, openairesponsesagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Tools: []tool.Tool{codeInterpreter},
+    },
+})
+```
+
+> [!NOTE]
+> Code interpreter is a hosted tool — code execution happens on the AI service side, not locally.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/file-search.md
+++ b/agent-framework/agents/tools/file-search.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: reference
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -127,6 +127,30 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## File search
+
+The `hostedtool.FileSearch` type enables server-side file search when using a provider that supports it (such as OpenAI Responses).
+
+```go
+import "github.com/microsoft/agent-framework-go/tool/hostedtool"
+
+fileSearch := &hostedtool.FileSearch{
+    MaximumResultCount: 10,
+}
+
+a := openairesponsesagent.New(client, openairesponsesagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Tools: []tool.Tool{fileSearch},
+    },
+})
+```
+
+> [!NOTE]
+> File search is a hosted tool — the search is performed by the AI service, not locally.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/function-tools.md
+++ b/agent-framework/agents/tools/function-tools.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: westey-m
 ms.topic: tutorial
 ms.author: westey
-ms.date: 03/16/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -178,6 +178,89 @@ This pattern is a good fit for long-lived tool state. Use `FunctionInvocationCon
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Function tools
+
+Function tools let agents call custom Go functions. The `functool` package provides a simple way to define type-safe tools with automatic schema generation.
+
+### Define a function tool
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/tool"
+    "github.com/microsoft/agent-framework-go/tool/functool"
+)
+
+var weatherTool = functool.MustNew(&functool.Func{
+    Name:        "weather",
+    Description: "Get the current weather for a given location",
+}, func(_ tool.Context, location string) (string, error) {
+    return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
+})
+```
+
+The function signature determines the tool's input schema. The `tool.Context` parameter is injected by the framework and is not exposed to the model.
+
+### Structured input types
+
+For tools with multiple parameters, define a struct:
+
+```go
+type WeatherInput struct {
+    Location string `json:"location" jsonschema:"description=The city to check weather for"`
+    Unit     string `json:"unit" jsonschema:"description=Temperature unit (celsius or fahrenheit),enum=celsius,enum=fahrenheit"`
+}
+
+var weatherTool = functool.MustNew(&functool.Func{
+    Name:        "weather",
+    Description: "Get weather for a location",
+}, func(_ tool.Context, input WeatherInput) (string, error) {
+    return fmt.Sprintf("Weather in %s: 15°%s", input.Location, input.Unit), nil
+})
+```
+
+### Create an agent with tools
+
+```go
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions: "You are a helpful assistant.",
+        Tools:        []tool.Tool{weatherTool},
+    },
+})
+
+resp, err := a.RunText(ctx, "What is the weather like in Amsterdam?").Collect()
+```
+
+### Use an agent as a function tool
+
+Any agent can be wrapped as a function tool for use by another agent:
+
+```go
+weatherAgent := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions: "You answer questions about the weather.",
+        Name:         "WeatherAgent",
+        Description:  "An agent that answers weather questions.",
+        Tools:        []tool.Tool{weatherTool},
+    },
+})
+
+mainAgent := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions: "You are a helpful assistant who responds in French.",
+        Tools:        []tool.Tool{weatherAgent.AsFuncTool()},
+    },
+})
+```
+
+> [!TIP]
+> See the [function tools sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step03_using_function_tools/main.go) and the [agent as tool sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/agents/step12_as_function_tool/main.go) for complete examples.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/hosted-mcp-tools.md
+++ b/agent-framework/agents/tools/hosted-mcp-tools.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: markwallace
 ms.topic: reference
 ms.author: markwallace
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -336,6 +336,34 @@ if __name__ == "__main__":
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Hosted MCP tools
+
+The `hostedtool` package provides marker types for hosted tools. These tools are not executed locally — they inform the AI service that it's allowed to perform certain actions server-side.
+
+### Hosted MCP Server
+
+```go
+import "github.com/microsoft/agent-framework-go/tool/hostedtool"
+
+mcpTool := &hostedtool.MCPServer{
+    ServerName:    "my-server",
+    ServerAddress: "https://mcp.example.com",
+    AllowedTools:  []string{"search", "analyze"},
+}
+
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Tools: []tool.Tool{mcpTool},
+    },
+})
+```
+
+> [!NOTE]
+> Hosted MCP tools require a provider that supports them, such as the OpenAI Responses API (`openairesponsesagent`).
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/index.md
+++ b/agent-framework/agents/tools/index.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: reference
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -157,6 +157,60 @@ weather_tool = weather_agent.as_tool(
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Tools overview
+
+Go agents support several tool types through the `tool` package:
+
+| Tool Type | Package | Description |
+|---|---|---|
+| Function tools | `tool/functool` | Custom Go functions the agent can call |
+| MCP tools | `tool/mcptool` | Tools from Model Context Protocol servers |
+| Hosted tools | `tool/hostedtool` | Service-side tools (web search, file search, code interpreter) |
+
+### Tool interface
+
+All tools implement the `tool.Tool` interface:
+
+```go
+type Tool interface {
+    Name() string
+    Description() string
+}
+```
+
+Function tools additionally implement `tool.FuncTool`:
+
+```go
+type FuncTool interface {
+    Tool
+    Schema() map[string]any
+    ReturnSchema() map[string]any
+    Call(ctx Context, arguments string) (any, error)
+}
+```
+
+### Registering tools
+
+Pass tools to the agent via `agent.Config.Tools`:
+
+```go
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions: "You are a helpful assistant.",
+        Tools: []tool.Tool{weatherTool, calculatorTool},
+    },
+})
+```
+
+Or add tools per-run:
+
+```go
+resp, err := a.RunText(ctx, "What's the weather?", agentopt.Tool(weatherTool)).Collect()
+```
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/local-mcp-tools.md
+++ b/agent-framework/agents/tools/local-mcp-tools.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: markwallace
 ms.topic: reference
 ms.author: markwallace
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -419,6 +419,56 @@ if __name__ == "__main__":
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Local MCP tools
+
+The `mcptool` package lets agents use tools from Model Context Protocol (MCP) servers.
+
+### Connect to an MCP server
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/tool/mcptool"
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+session, err := mcptool.Connect(ctx, &mcp.StreamableClientTransport{
+    Endpoint: "https://learn.microsoft.com/api/mcp",
+})
+if err != nil {
+    panic(err)
+}
+defer session.Close()
+```
+
+### List and use MCP tools
+
+```go
+tools, err := mcptool.ListTools(ctx, session)
+if err != nil {
+    panic(err)
+}
+
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: "gpt-4o-mini",
+    Config: agent.Config{
+        Instructions: "You are a helpful assistant.",
+        Tools:        tools,
+    },
+})
+
+resp, err := a.RunText(ctx, "How to create an Azure storage account using az cli?").Collect()
+```
+
+### Supported transports
+
+- **HTTP/SSE** — `mcp.StreamableClientTransport{Endpoint: "https://..."}`
+- **Stdio** — Launch a local MCP server process
+
+> [!TIP]
+> See the [MCP tools sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/02-agents/mcp/agent_mcp_server/main.go) for a complete runnable example.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/tool-approval.md
+++ b/agent-framework/agents/tools/tool-approval.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: westey-m
 ms.topic: tutorial
 ms.author: westey
-ms.date: 04/01/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -405,6 +405,28 @@ if __name__ == "__main__":
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Tool approval
+
+You can require human approval before a tool is executed by wrapping it with `tool.ApprovalRequiredFunc`:
+
+```go
+import "github.com/microsoft/agent-framework-go/tool"
+
+approvedWeatherTool := tool.ApprovalRequiredFunc(weatherTool)
+
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Instructions: "You are a helpful assistant.",
+        Tools:        []tool.Tool{approvedWeatherTool},
+    },
+})
+```
+
+When the model requests a tool call, the framework intercepts it and waits for approval before executing. The approval flow is handled through middleware.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/agents/tools/web-search.md
+++ b/agent-framework/agents/tools/web-search.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: reference
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -102,6 +102,28 @@ if __name__ == "__main__":
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Web search
+
+The `hostedtool.WebSearch` type enables server-side web search when using a provider that supports it.
+
+```go
+import "github.com/microsoft/agent-framework-go/tool/hostedtool"
+
+webSearch := &hostedtool.WebSearch{}
+
+a := openairesponsesagent.New(client, openairesponsesagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Tools: []tool.Tool{webSearch},
+    },
+})
+```
+
+> [!NOTE]
+> Web search is a hosted tool — the search is performed by the AI service, not locally.
+
+:::zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/devui/api-reference.md
+++ b/agent-framework/devui/api-reference.md
@@ -218,6 +218,12 @@ curl -X POST http://localhost:8080/v1/responses \
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next Steps
 
 - [Tracing & Observability](./tracing.md) - View traces for debugging

--- a/agent-framework/devui/directory-discovery.md
+++ b/agent-framework/devui/directory-discovery.md
@@ -135,6 +135,12 @@ When DevUI starts with no discovered entities, it displays a **sample gallery** 
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next Steps
 
 - [API Reference](./api-reference.md) - Learn about the OpenAI-compatible API

--- a/agent-framework/devui/index.md
+++ b/agent-framework/devui/index.md
@@ -139,6 +139,12 @@ Options:
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next Steps
 
 - [Directory Discovery](./directory-discovery.md) - Learn how to structure your agents for automatic discovery

--- a/agent-framework/devui/samples.md
+++ b/agent-framework/devui/samples.md
@@ -124,6 +124,12 @@ workflow = (
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next Steps
 
 - [Overview](./index.md) - Return to DevUI overview

--- a/agent-framework/devui/security.md
+++ b/agent-framework/devui/security.md
@@ -185,6 +185,12 @@ serve(entities=[agent])
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next Steps
 
 - [Samples](./samples.md) - Browse sample agents and workflows

--- a/agent-framework/devui/tracing.md
+++ b/agent-framework/devui/tracing.md
@@ -107,6 +107,12 @@ Without an OTLP endpoint, traces are captured locally and displayed only in the 
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Related Documentation
 
 For more details on Agent Framework observability:

--- a/agent-framework/get-started/add-tools.md
+++ b/agent-framework/get-started/add-tools.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: tutorial
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -71,6 +71,59 @@ Create an agent with the tool:
 
 > [!TIP]
 > See the [full sample](https://github.com/microsoft/agent-framework/blob/main/python/samples/01-get-started/02_add_tools.py) for the complete runnable file.
+
+:::zone-end
+
+:::zone pivot="programming-language-go"
+
+Define a tool using `functool`:
+
+```go
+import (
+	"fmt"
+
+	"github.com/microsoft/agent-framework-go/tool"
+	"github.com/microsoft/agent-framework-go/tool/functool"
+)
+
+var weatherTool = functool.MustNew(&functool.Func{
+	Name:        "weather",
+	Description: "Get the current weather for a given location",
+}, func(_ tool.Context, location string) (string, error) {
+	return fmt.Sprintf("The weather in %s is cloudy with a high of 15°C.", location), nil
+})
+```
+
+Create an agent with the tool:
+
+```go
+a := openaichatagent.New(
+	openai.NewClient(
+		azure.WithEndpoint(endpoint, apiVersion),
+		azure.WithTokenCredential(token),
+	),
+	openaichatagent.Config{
+		Model: deployment,
+		Config: agent.Config{
+			Instructions: "You are a helpful assistant",
+			Tools:        []tool.Tool{weatherTool},
+		},
+	},
+)
+```
+
+The agent will automatically call your tool when relevant:
+
+```go
+resp, err := a.RunText(ctx, "What is the weather like in Amsterdam?").Collect()
+if err != nil {
+	panic(err)
+}
+fmt.Println(resp)
+```
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/01-get-started/02_add_tools/main.go) for the complete runnable file.
 
 :::zone-end
 

--- a/agent-framework/get-started/hosting.md
+++ b/agent-framework/get-started/hosting.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: tutorial
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -162,6 +162,56 @@ curl -X POST http://localhost:7071/api/agents/Joker/run \
 
 > [!TIP]
 > See the [full sample](https://github.com/microsoft/agent-framework/blob/main/python/samples/04-hosting/azure_functions/01_single_agent/function_app.py) for the complete runnable file, and the [Azure Functions hosting samples](https://github.com/microsoft/agent-framework/tree/main/python/samples/04-hosting/azure_functions) for more patterns.
+
+:::zone-end
+
+:::zone pivot="programming-language-go"
+
+## Hosting with A2A Protocol
+
+The Go port provides A2A hosting through `a2ahosting`, which wraps an agent in an HTTP handler compatible with the Agent-to-Agent protocol.
+
+Create an agent:
+
+```go
+import (
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/hosting/a2ahosting"
+	"github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv"
+)
+
+a := openaichatagent.New(client, openaichatagent.Config{
+	Model: deployment,
+	Config: agent.Config{
+		Instructions: "You are a helpful assistant.",
+	},
+})
+```
+
+Expose the agent via A2A:
+
+```go
+card := &a2a.AgentCard{
+	URL:             "http://localhost:5000",
+	ProtocolVersion: "0.3.0",
+	Version:         "1.0.0",
+	Capabilities:    a2a.AgentCapabilities{Streaming: false},
+}
+
+mux := http.NewServeMux()
+mux.Handle("/", a2ahosting.NewHTTPHandler(a2ahosting.ExecutorConfig{
+	Agent: a,
+}, a2asrv.WithExtendedAgentCard(card)))
+mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(card))
+
+log.Println("A2A server listening on :5000")
+http.ListenAndServe(":5000", mux)
+```
+
+> [!TIP]
+> See the [full A2A client-server sample](https://github.com/microsoft/agent-framework-go/tree/main/examples/05-end-to-end/a2a_client_server) for a complete runnable example.
 
 :::zone-end
 

--- a/agent-framework/get-started/memory.md
+++ b/agent-framework/get-started/memory.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: tutorial
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -118,6 +118,93 @@ Run it — the agent now has access to the context:
 >     context_providers=[memory_store, agent_memory, audit_store],  # audit store last
 > )
 > ```
+
+:::zone-end
+
+:::zone pivot="programming-language-go"
+
+Define a context provider that stores user info in session state and injects personalization instructions:
+
+```go
+import (
+	"github.com/microsoft/agent-framework-go/memory"
+	"github.com/microsoft/agent-framework-go/message"
+)
+
+const userMemorySourceID = "user_memory"
+
+type providerState struct {
+	UserName string `json:"user_name,omitempty"`
+}
+
+func newUserMemoryProvider() *memory.ContextProvider {
+	return &memory.ContextProvider{
+		SourceID: userMemorySourceID,
+		Provide:  provideUserMemory,
+		Store:    storeUserMemory,
+	}
+}
+
+func provideUserMemory(ctx memory.BeforeRunContext) (memory.Context, error) {
+	var state providerState
+	ctx.Session.Get(userMemorySourceID, &state)
+
+	instructions := "You don't know the user's name yet. Ask for it politely."
+	if state.UserName != "" {
+		instructions = fmt.Sprintf("The user's name is %s. Always address them by name.", state.UserName)
+	}
+	return memory.Context{Messages: []*message.Message{{
+		Role: message.RoleSystem,
+		Contents: []message.Content{
+			&message.TextContent{Text: instructions},
+		},
+	}}}, nil
+}
+```
+
+Create an agent with the context provider:
+
+```go
+a := openaichatagent.New(
+	openai.NewClient(
+		azure.WithEndpoint(endpoint, apiVersion),
+		azure.WithTokenCredential(token),
+	),
+	openaichatagent.Config{
+		Model: deployment,
+		Config: agent.Config{
+			Instructions:     "You are a friendly assistant.",
+			Name:             "MemoryAgent",
+			ContextProviders: []*memory.ContextProvider{newUserMemoryProvider()},
+		},
+	},
+)
+```
+
+Run it — the agent now has access to the context:
+
+```go
+ctx := context.Background()
+session, err := a.CreateSession(ctx)
+if err != nil {
+	panic(err)
+}
+
+// The provider doesn't know the user yet.
+resp, err := a.RunText(ctx, "Hello, what is the square root of 9?", agentopt.Session(session)).Collect()
+fmt.Println(resp)
+
+// Teach the provider the user's name.
+resp, err = a.RunText(ctx, "My name is Alice", agentopt.Session(session)).Collect()
+fmt.Println(resp)
+
+// Subsequent calls are personalized using session state.
+resp, err = a.RunText(ctx, "What is 2 + 2?", agentopt.Session(session)).Collect()
+fmt.Println(resp)
+```
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/01-get-started/04_memory/main.go) for the complete runnable file.
 
 :::zone-end
 

--- a/agent-framework/get-started/multi-turn.md
+++ b/agent-framework/get-started/multi-turn.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: tutorial
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -61,6 +61,53 @@ Use `AgentSession` to maintain context across multiple calls:
 
 > [!TIP]
 > See the [full sample](https://github.com/microsoft/agent-framework/blob/main/python/samples/01-get-started/03_multi_turn.py) for the complete runnable file.
+
+:::zone-end
+
+:::zone pivot="programming-language-go"
+
+Use `CreateSession` to maintain context across multiple calls:
+
+```go
+a := openaichatagent.New(
+	openai.NewClient(
+		azure.WithEndpoint(endpoint, apiVersion),
+		azure.WithTokenCredential(token),
+	),
+	openaichatagent.Config{
+		Model: deployment,
+		Config: agent.Config{
+			Instructions: "You are a friendly assistant. Keep your answers brief.",
+			Name:         "ConversationAgent",
+		},
+	},
+)
+
+ctx := context.Background()
+
+// Create a session to maintain conversation history.
+session, err := a.CreateSession(ctx)
+if err != nil {
+	panic(err)
+}
+
+// First turn.
+resp, err := a.RunText(ctx, "My name is Alice and I love hiking.", agentopt.Session(session)).Collect()
+if err != nil {
+	panic(err)
+}
+fmt.Println(resp)
+
+// Second turn — the agent remembers the user's name and hobby.
+resp, err = a.RunText(ctx, "What do you remember about me?", agentopt.Session(session)).Collect()
+if err != nil {
+	panic(err)
+}
+fmt.Println(resp)
+```
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/01-get-started/03_multi_turn/main.go) for the complete runnable file.
 
 :::zone-end
 

--- a/agent-framework/get-started/workflows.md
+++ b/agent-framework/get-started/workflows.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: tutorial
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -69,6 +69,63 @@ Build and run the workflow:
 
 > [!TIP]
 > See the [full sample](https://github.com/microsoft/agent-framework/blob/main/python/samples/01-get-started/05_first_workflow.py) for the complete runnable file.
+
+:::zone-end
+
+:::zone pivot="programming-language-go"
+
+Define workflow steps (executors) and connect them with edges:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/agent-framework-go/workflow"
+	"github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+func main() {
+	// Step 1: Convert text to uppercase.
+	uppercase := workflow.BindFunc("UppercaseExecutor", true, func(input string) string {
+		return strings.ToUpper(input)
+	})
+
+	// Step 2: Reverse the string.
+	reverse := workflow.BindFunc("ReverseExecutor", true, func(input string) string {
+		runes := []rune(input)
+		slices.Reverse(runes)
+		return string(runes)
+	})
+
+	// Build the workflow by connecting executors sequentially.
+	wf, err := workflow.NewBuilder(uppercase).
+		AddEdge(uppercase, reverse).
+		WithOutputFrom(reverse).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	// Execute the workflow with sample input.
+	run, err := inproc.Run(context.Background(), wf, "", "Hello, World!")
+	if err != nil {
+		panic(err)
+	}
+	for evt := range run.NewEvents() {
+		if evt, ok := evt.(workflow.ExecutorCompletedEvent); ok {
+			fmt.Printf("%s: %v\n", evt.ExecutorID, evt.Result)
+		}
+	}
+}
+```
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/01-get-started/05_first_workflow/main.go) for the complete runnable file.
 
 :::zone-end
 

--- a/agent-framework/get-started/your-first-agent.md
+++ b/agent-framework/get-started/your-first-agent.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: eavanvalkenburg
 ms.topic: tutorial
 ms.author: edvan
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -91,6 +91,81 @@ Or stream the response:
 
 > [!TIP]
 > See the [full sample](https://github.com/microsoft/agent-framework/blob/main/python/samples/01-get-started/01_hello_agent.py) for the complete runnable file.
+
+:::zone-end
+
+:::zone pivot="programming-language-go"
+
+```bash
+go get github.com/microsoft/agent-framework-go
+```
+
+Create and run an agent:
+
+```go
+package main
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/microsoft/agent-framework-go/agent"
+	"github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/azure"
+)
+
+func main() {
+	endpoint := os.Getenv("AZURE_OPENAI_ENDPOINT")
+	deployment := cmp.Or(os.Getenv("AZURE_OPENAI_DEPLOYMENT_NAME"), "gpt-4o-mini")
+	apiVersion := cmp.Or(os.Getenv("AZURE_OPENAI_API_VERSION"), "2025-01-01-preview")
+
+	token, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	a := openaichatagent.New(
+		openai.NewClient(
+			azure.WithEndpoint(endpoint, apiVersion),
+			azure.WithTokenCredential(token),
+		),
+		openaichatagent.Config{
+			Model: deployment,
+			Config: agent.Config{
+				Instructions: "You are a friendly assistant. Keep your answers brief.",
+				Name:         "HelloAgent",
+			},
+		},
+	)
+
+	ctx := context.Background()
+
+	// Invoke the agent and collect the text result.
+	resp, err := a.RunText(ctx, "What is the largest city in France?").Collect()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(resp)
+}
+```
+
+Or stream the response:
+
+```go
+for update, err := range a.RunText(ctx, "Tell me a one-sentence fun fact.", agentopt.Stream(true)) {
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(update)
+}
+```
+
+> [!TIP]
+> See the [full sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/01-get-started/01_hello_agent/main.go) for the complete runnable file.
 
 :::zone-end
 

--- a/agent-framework/integrations/a2a.md
+++ b/agent-framework/integrations/a2a.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: dmkorolev
 ms.service: agent-framework
 ms.topic: tutorial
-ms.date: 02/11/2026
+ms.date: 04/22/2026
 ms.author: dmkorolev
 ---
 
@@ -332,6 +332,61 @@ async with A2AAgent(
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## A2A Protocol
+
+The Go Agent Framework supports the Agent-to-Agent (A2A) protocol for both hosting and consuming agents.
+
+### Host an agent via A2A
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/agent/hosting/a2ahosting"
+    "github.com/a2aproject/a2a-go/a2a"
+    "github.com/a2aproject/a2a-go/a2asrv"
+)
+
+card := &a2a.AgentCard{
+    URL:             "http://localhost:5000",
+    ProtocolVersion: "0.3.0",
+    Version:         "1.0.0",
+    Capabilities:    a2a.AgentCapabilities{Streaming: false},
+}
+
+mux := http.NewServeMux()
+mux.Handle("/", a2ahosting.NewHTTPHandler(a2ahosting.ExecutorConfig{
+    Agent: myAgent,
+}, a2asrv.WithExtendedAgentCard(card)))
+mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(card))
+
+http.ListenAndServe(":5000", mux)
+```
+
+### Consume an A2A agent
+
+```go
+import (
+    "github.com/a2aproject/a2a-go/a2aclient"
+    "github.com/a2aproject/a2a-go/a2aclient/agentcard"
+    "github.com/microsoft/agent-framework-go/agent/provider/a2aagent"
+)
+
+card, _ := agentcard.DefaultResolver.Resolve(ctx, "http://localhost:5000")
+client, _ := a2aclient.NewFromCard(ctx, card)
+
+a := a2aagent.New(client, a2aagent.Config{
+    Config: agent.Config{
+        Name: "RemoteAgent",
+    },
+})
+
+resp, err := a.RunText(ctx, "Hello!").Collect()
+```
+
+> [!TIP]
+> See the [A2A client-server sample](https://github.com/microsoft/agent-framework-go/tree/main/examples/05-end-to-end/a2a_client_server) for a complete example.
+
+::: zone-end
 ## See Also
 
 - [Integrations Overview](./index.md)

--- a/agent-framework/integrations/ag-ui/backend-tool-rendering.md
+++ b/agent-framework/integrations/ag-ui/backend-tool-rendering.md
@@ -712,3 +712,10 @@ Now that you understand backend tool rendering, you can:
 - [Function Tools Tutorial](../../agents/tools/function-tools.md)
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/integrations/ag-ui/frontend-tools.md
+++ b/agent-framework/integrations/ag-ui/frontend-tools.md
@@ -573,3 +573,10 @@ async def capture_photo() -> str:
 - [Agent Framework Documentation](../../overview/index.md)
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/integrations/ag-ui/getting-started.md
+++ b/agent-framework/integrations/ag-ui/getting-started.md
@@ -791,3 +791,10 @@ Now that you understand the basics of AG-UI, you can:
 - [AG-UI Protocol Specification](https://docs.ag-ui.com/)
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/integrations/ag-ui/human-in-the-loop.md
+++ b/agent-framework/integrations/ag-ui/human-in-the-loop.md
@@ -1130,3 +1130,10 @@ Now that you understand human-in-the-loop, you can:
 - [Function Tools with Approvals](../../agents/tools/tool-approval.md)
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/integrations/ag-ui/index.md
+++ b/agent-framework/integrations/ag-ui/index.md
@@ -255,3 +255,10 @@ To get started with AG-UI integration:
 - [Agent Framework GitHub Repository](https://github.com/microsoft/agent-framework)
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/integrations/ag-ui/state-management.md
+++ b/agent-framework/integrations/ag-ui/state-management.md
@@ -986,3 +986,10 @@ You've now learned all the core AG-UI features! Next you can:
 <!-- - [Human-in-the-Loop](human-in-the-loop.md) -->
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/integrations/ag-ui/testing-with-dojo.md
+++ b/agent-framework/integrations/ag-ui/testing-with-dojo.md
@@ -243,6 +243,12 @@ If you see authentication errors:
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ::: zone pivot="programming-language-csharp"
 
 Coming soon.

--- a/agent-framework/integrations/azure-functions.md
+++ b/agent-framework/integrations/azure-functions.md
@@ -1335,6 +1335,12 @@ def agent_orchestration_workflow(context: df.DurableOrchestrationContext):
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ### Test the orchestration
 
 Ensure your local development dependencies from the first tutorial are still running:

--- a/agent-framework/integrations/chat-history-memory-provider.md
+++ b/agent-framework/integrations/chat-history-memory-provider.md
@@ -192,6 +192,12 @@ This provider is not yet available for Python. See the C# tab for usage examples
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/integrations/index.md
+++ b/agent-framework/integrations/index.md
@@ -100,6 +100,12 @@ Here is a list of existing providers that can be used.
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/integrations/neo4j-graphrag.md
+++ b/agent-framework/integrations/neo4j-graphrag.md
@@ -201,6 +201,12 @@ async with (
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/integrations/neo4j-memory.md
+++ b/agent-framework/integrations/neo4j-memory.md
@@ -119,6 +119,12 @@ async with memory_client:
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/integrations/openai-endpoints.md
+++ b/agent-framework/integrations/openai-endpoints.md
@@ -612,6 +612,12 @@ export AZURE_OPENAI_API_VERSION="your-api-version"
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## See Also
 
 - [Integrations Overview](./index.md)

--- a/agent-framework/integrations/purview.md
+++ b/agent-framework/integrations/purview.md
@@ -141,3 +141,10 @@ Now that you added the above code to your agent, perform the following steps to 
 - [Code Sample: Purview Policy Enforcement Sample (Python)](https://github.com/microsoft/agent-framework/tree/main/python/samples/05-end-to-end/purview_agent).
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/migration-guide/from-semantic-kernel/index.md
+++ b/agent-framework/migration-guide/from-semantic-kernel/index.md
@@ -809,6 +809,12 @@ response = await agent.run(
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/migration-guide/from-semantic-kernel/samples.md
+++ b/agent-framework/migration-guide/from-semantic-kernel/samples.md
@@ -22,6 +22,12 @@ See the [Agent Framework repository](https://github.com/microsoft/agent-framewor
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/overview/index.md
+++ b/agent-framework/overview/index.md
@@ -3,7 +3,7 @@ title: Microsoft Agent Framework Overview
 description: "Build AI agents and multi-agent workflows in .NET and Python with Microsoft Agent Framework."
 zone_pivot_groups: programming-languages
 ms.topic: overview
-ms.date: 02/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 author: markwallace-microsoft
 ms.author: markwallace
@@ -91,6 +91,40 @@ That's it — an agent that calls an LLM and returns a response. From here you c
 
 :::zone-end
 
+:::zone pivot="programming-language-go"
+## Getting started with Go
+
+Install the framework:
+
+```bash
+go get github.com/microsoft/agent-framework-go
+```
+
+Create your first agent:
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/agent"
+    "github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+    "github.com/openai/openai-go/v3"
+)
+
+a := openaichatagent.New(
+    openai.NewClient(),
+    openaichatagent.Config{
+        Model: "gpt-4o-mini",
+        Config: agent.Config{
+            Instructions: "You are a helpful assistant.",
+        },
+    },
+)
+
+resp, err := a.RunText(ctx, "Hello!").Collect()
+```
+
+For step-by-step tutorials, see the [Get Started guide](../get-started/your-first-agent.md).
+
+:::zone-end
 > [!div class="nextstepaction"]
 > [Get Started — full tutorial](../get-started/your-first-agent.md)
 

--- a/agent-framework/support/troubleshooting.md
+++ b/agent-framework/support/troubleshooting.md
@@ -34,6 +34,12 @@ Ensure you're using .NET 8.0 SDK or later. Run `dotnet --version` to check your 
 Ensure you're using Python 3.10 or later. Run `python --version` to check your installed version.
 :::zone-end
 
+:::zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+:::zone-end
 ## Getting Help
 
 If you can't find a solution here, visit our [GitHub Discussions](https://github.com/microsoft/agent-framework/discussions) for community support.

--- a/agent-framework/workflows/advanced/agent-executor.md
+++ b/agent-framework/workflows/advanced/agent-executor.md
@@ -344,6 +344,12 @@ On restore, the executor deserializes this state, allowing the workflow to resum
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/advanced/execution-modes.md
+++ b/agent-framework/workflows/advanced/execution-modes.md
@@ -143,3 +143,10 @@ Execution modes are not applicable to Python workflows. Python workflows use a s
 For information on running Python workflows, see [Workflow Builder & Execution](../workflows.md).
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/workflows/advanced/resettable-executors.md
+++ b/agent-framework/workflows/advanced/resettable-executors.md
@@ -124,6 +124,12 @@ This concept does not apply to Python. For full state isolation, build fresh wor
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/advanced/sub-workflows.md
+++ b/agent-framework/workflows/advanced/sub-workflows.md
@@ -561,6 +561,12 @@ async for event in parent_workflow.run(
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/agents-in-workflows.md
+++ b/agent-framework/workflows/agents-in-workflows.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: tutorial
 ms.author: taochen
-ms.date: 03/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -337,6 +337,55 @@ For the complete working implementation, see [azure_ai_agents_streaming.py](http
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Agents in workflows
+
+Agents can be used as workflow executors, enabling AI-powered workflow steps.
+
+### Bind an agent as an executor
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/agent/provider/openaichatagent"
+    "github.com/microsoft/agent-framework-go/workflow"
+    "github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+frenchAgent := openaichatagent.New(client, openaichatagent.Config{
+    Model: "gpt-4o-mini",
+    Config: agent.Config{
+        Instructions: "You translate text to French.",
+    },
+})
+
+spanishAgent := openaichatagent.New(client, openaichatagent.Config{
+    Model: "gpt-4o-mini",
+    Config: agent.Config{
+        Instructions: "You translate text to Spanish.",
+    },
+})
+
+french := frenchAgent.Bind(false)
+spanish := spanishAgent.Bind(false)
+
+wf, err := workflow.NewBuilder(french).
+    AddEdge(french, spanish).
+    Build()
+
+run, err := inproc.Stream(ctx, wf, "", message.NewText("Hello World"))
+emitEvents := true
+run.SendMessage(ctx, workflow.TurnToken{EmitEvents: &emitEvents})
+for evt, err := range run.WatchStream(ctx) {
+    if evt, ok := evt.(workflow.ResponseUpdateEvent); ok {
+        fmt.Printf("%s: %v\n", evt.ExecutorID, evt.Update)
+    }
+}
+```
+
+> [!TIP]
+> See the [agents in workflows sample](https://github.com/microsoft/agent-framework-go/blob/main/examples/03-workflows/_start-here/03_agents/main.go) for a complete example.
+
+::: zone-end
 ## Next Steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/as-agents.md
+++ b/agent-framework/workflows/as-agents.md
@@ -406,6 +406,12 @@ This conversion allows you to use the standard agent interface while still havin
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Use Cases
 
 ### 1. Complex Agent Pipelines

--- a/agent-framework/workflows/checkpoints.md
+++ b/agent-framework/workflows/checkpoints.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: tutorial
 ms.author: taochen
-ms.date: 03/11/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -285,6 +285,36 @@ If your threat model does not permit pickle-based serialization, use `InMemoryCh
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Checkpoints
+
+Workflows support checkpointing to pause and resume execution.
+
+### Checkpoint hooks
+
+Executors can save and restore state at checkpoints through `ExecutorConfig`:
+
+```go
+config := &workflow.ExecutorConfig{
+    OnCheckpoint: func(ctx context.Context) error {
+        // Save executor state
+        return nil
+    },
+    OnCheckpointRestored: func(ctx context.Context) error {
+        // Restore executor state
+        return nil
+    },
+}
+```
+
+### Resume from checkpoint
+
+```go
+checkpoints := run.Checkpoints()
+restored, err := inproc.RestoreCheckpoint(ctx, wf, checkpoints[0])
+```
+
+::: zone-end
 ## Next Steps
 
 - [Learn how to monitor workflows](./observability.md).

--- a/agent-framework/workflows/declarative.md
+++ b/agent-framework/workflows/declarative.md
@@ -3139,3 +3139,10 @@ actions:
 - [Python Declarative Workflow Samples](https://github.com/microsoft/agent-framework/tree/main/python/samples/03-workflows/declarative) - Explore complete working examples
 
 ::: zone-end
+
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end

--- a/agent-framework/workflows/edges.md
+++ b/agent-framework/workflows/edges.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: conceptual
 ms.author: taochen
-ms.date: 03/05/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -2240,6 +2240,24 @@ For the complete working implementation, see the [multi_selection_edge_group.py]
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Edges
+
+Edges define data flow between executors in a workflow.
+
+### Connect executors
+
+```go
+wf, err := workflow.NewBuilder(executorA).
+    AddEdge(executorA, executorB).
+    AddEdge(executorB, executorC).
+    WithOutputFrom(executorC).
+    Build()
+```
+
+Edges route the output of one executor to the input of the next. The builder API provides a fluent interface for defining the workflow graph.
+
+::: zone-end
 ## Next Steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/events.md
+++ b/agent-framework/workflows/events.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: conceptual
 ms.author: taochen
-ms.date: 03/05/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -277,6 +277,37 @@ async for event in workflow.run(input_message, stream=True):
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Events
+
+Workflows emit events during execution. Events can be observed through the run object.
+
+### Observe events
+
+```go
+run, err := inproc.Run(ctx, wf, "", input)
+for evt := range run.NewEvents() {
+    switch e := evt.(type) {
+    case workflow.ExecutorCompletedEvent:
+        fmt.Printf("Executor %s completed: %v\n", e.ExecutorID, e.Result)
+    case workflow.ResponseUpdateEvent:
+        fmt.Printf("Agent %s: %v\n", e.ExecutorID, e.Update)
+    }
+}
+```
+
+### Streaming events
+
+For streaming workflows, use `inproc.Stream` and `WatchStream`:
+
+```go
+run, err := inproc.Stream(ctx, wf, "", input)
+for evt := range run.WatchStream(ctx) {
+    // process streaming events
+}
+```
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/executors.md
+++ b/agent-framework/workflows/executors.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: conceptual
 ms.author: taochen
-ms.date: 03/24/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -240,6 +240,44 @@ class LogExecutor(Executor):
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Executors
+
+Executors are the processing units in a workflow. They receive input, perform work, and produce output.
+
+### Function executors
+
+The simplest way to create an executor is with `workflow.BindFunc`:
+
+```go
+uppercase := workflow.BindFunc("UppercaseExecutor", true, func(input string) string {
+    return strings.ToUpper(input)
+})
+```
+
+The second parameter (`true`) indicates that the executor auto-completes (returns a result immediately).
+
+### Agent executors
+
+Agents can be used as workflow executors via `agent.Bind`:
+
+```go
+agentExecutor := myAgent.Bind(false) // false = manual completion via events
+```
+
+### Executor lifecycle
+
+Executors support lifecycle hooks through `workflow.ExecutorConfig`:
+
+| Hook | Purpose |
+|---|---|
+| `ConfigureRoutes` | Set up message routing |
+| `Initialize` | Setup when workflow starts |
+| `Reset` | Reset state between runs |
+| `OnCheckpoint` | Save state at checkpoint |
+| `OnCheckpointRestored` | Restore state from checkpoint |
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/human-in-the-loop.md
+++ b/agent-framework/workflows/human-in-the-loop.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: tutorial
 ms.author: taochen
-ms.date: 03/09/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -231,6 +231,22 @@ while pending_responses is not None:
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Human in the loop
+
+Workflows support human-in-the-loop patterns through `RequestPort`, which pauses execution and waits for external input.
+
+### RequestPort
+
+```go
+import "github.com/microsoft/agent-framework-go/workflow"
+```
+
+A `RequestPort` defines a typed request/response channel between the workflow and the outside world. When an executor reaches a request port, the workflow pauses and emits an external request event. The workflow resumes when an external response is provided.
+
+This enables approval flows, user input collection, and other interactive patterns within automated workflows.
+
+::: zone-end
 ## Human-in-the-Loop with Agent Orchestrations
 
 The `RequestPort` pattern described above works with custom executors and `WorkflowBuilder`. When using **agent orchestrations** (such as sequential, concurrent, or group chat workflows), **tool approval** is achieved through the human-in-the-loop request/response mechanism.

--- a/agent-framework/workflows/observability.md
+++ b/agent-framework/workflows/observability.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: tutorial
 ms.author: taochen
-ms.date: 03/11/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -215,6 +215,40 @@ Workflow telemetry is enabled through the global `enable_instrumentation()` func
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Workflow observability
+
+Workflows can be traced using the same OpenTelemetry middleware used for agents.
+
+### Add tracing to agent executors
+
+When agents are used as workflow executors, their middleware (including the OTEL middleware) is active during workflow execution:
+
+```go
+a := openaichatagent.New(client, openaichatagent.Config{
+    Model: deployment,
+    Config: agent.Config{
+        Middlewares: []middleware.Middleware{
+            otel.New(otel.Config{}),
+        },
+    },
+})
+```
+
+### Observe workflow events
+
+Monitor workflow execution through event streams:
+
+```go
+for evt := range run.NewEvents() {
+    switch e := evt.(type) {
+    case workflow.ExecutorCompletedEvent:
+        log.Printf("Executor %s completed", e.ExecutorID)
+    }
+}
+```
+
+::: zone-end
 ## Next Steps
 
 - [Learn about state isolation in workflows](./state.md).

--- a/agent-framework/workflows/orchestrations/concurrent.md
+++ b/agent-framework/workflows/orchestrations/concurrent.md
@@ -434,6 +434,12 @@ critical before launch.
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/orchestrations/group-chat.md
+++ b/agent-framework/workflows/orchestrations/group-chat.md
@@ -444,6 +444,12 @@ workflow = GroupChatBuilder(
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Context Synchronization
 
 As mentioned at the beginning of this guide, all agents in a group chat see the full conversation history.

--- a/agent-framework/workflows/orchestrations/handoff.md
+++ b/agent-framework/workflows/orchestrations/handoff.md
@@ -653,6 +653,12 @@ After broadcasting the response, the participant then checks whether it needs to
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## The Handoff Agent Executor
 
 Unlike standard workflows where agents are wrapped in a general-purpose [Agent Executor](../advanced/agent-executor.md), handoff orchestration uses a specialized `HandoffAgentExecutor`. This executor extends the base agent executor with handoff-specific capabilities:

--- a/agent-framework/workflows/orchestrations/magentic.md
+++ b/agent-framework/workflows/orchestrations/magentic.md
@@ -303,6 +303,12 @@ See complete samples in the [Agent Framework Samples repository](https://github.
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/orchestrations/sequential.md
+++ b/agent-framework/workflows/orchestrations/sequential.md
@@ -474,6 +474,12 @@ while pending_responses is not None:
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 ## Next steps
 
 > [!div class="nextstepaction"]

--- a/agent-framework/workflows/state.md
+++ b/agent-framework/workflows/state.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: conceptual
 ms.author: taochen
-ms.date: 04/02/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -320,6 +320,21 @@ workflow_b = create_workflow()
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Workflow state
+
+Workflows manage state through scoped storage on the `Run` object.
+
+### State scoping
+
+Executors can store state in different scopes:
+
+- **Local scope** — Private to the executor instance
+- **Named scope** — Shared across executors with the same scope key
+
+State is accessed through the workflow context and persists across workflow events within a run.
+
+::: zone-end
 ## Summary
 
 State isolation in Microsoft Agent Framework Workflows can be effectively managed by wrapping executor and agent instantiation along with workflow building inside helper methods. By calling the helper method each time you need a new workflow, you ensure each instance has fresh, independent state and avoid unintended state sharing between different workflow executions.

--- a/agent-framework/workflows/visualization.md
+++ b/agent-framework/workflows/visualization.md
@@ -107,6 +107,12 @@ For a complete working implementation with visualization, see the [Concurrent wi
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+
+> [!NOTE]
+> Go support for this feature is coming soon. See the [Agent Framework Go repository](https://github.com/microsoft/agent-framework-go) for the latest status.
+
+::: zone-end
 The exported diagram will look similar to the following for the example workflow:
 
 ```mermaid

--- a/agent-framework/workflows/workflows.md
+++ b/agent-framework/workflows/workflows.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: TaoChenOSU
 ms.topic: conceptual
 ms.author: taochen
-ms.date: 03/05/2026
+ms.date: 04/22/2026
 ms.service: agent-framework
 ---
 
@@ -118,6 +118,53 @@ print(f"Final result: {events.get_outputs()}")
 
 ::: zone-end
 
+::: zone pivot="programming-language-go"
+## Workflows overview
+
+The `workflow` package provides a graph-based execution model where executors are connected by edges.
+
+### Key concepts
+
+- **Executor** — A processing unit that receives input and produces output
+- **Edge** — Connects the output of one executor to the input of another
+- **Builder** — Constructs workflows by defining executors and edges
+- **Run** — Executes a workflow with given input
+
+### Create a simple workflow
+
+```go
+import (
+    "github.com/microsoft/agent-framework-go/workflow"
+    "github.com/microsoft/agent-framework-go/workflow/inproc"
+)
+
+uppercase := workflow.BindFunc("UppercaseExecutor", true, func(input string) string {
+    return strings.ToUpper(input)
+})
+
+reverse := workflow.BindFunc("ReverseExecutor", true, func(input string) string {
+    runes := []rune(input)
+    slices.Reverse(runes)
+    return string(runes)
+})
+
+wf, err := workflow.NewBuilder(uppercase).
+    AddEdge(uppercase, reverse).
+    WithOutputFrom(reverse).
+    Build()
+
+run, err := inproc.Run(context.Background(), wf, "", "Hello, World!")
+for evt := range run.NewEvents() {
+    if evt, ok := evt.(workflow.ExecutorCompletedEvent); ok {
+        fmt.Printf("%s: %v\n", evt.ExecutorID, evt.Result)
+    }
+}
+```
+
+> [!TIP]
+> See the [workflow examples](https://github.com/microsoft/agent-framework-go/tree/main/examples/03-workflows) for complete runnable samples.
+
+::: zone-end
 ## Workflow Validation
 
 The framework performs comprehensive validation when building workflows:

--- a/agent-framework/zone-pivot-groups.yml
+++ b/agent-framework/zone-pivot-groups.yml
@@ -8,3 +8,5 @@ groups:
     title: C#
   - id: programming-language-python
     title: Python
+  - id: programming-language-go
+    title: Go


### PR DESCRIPTION
## Summary

Add Go as a supported language across the Agent Framework documentation, matching the [agent-framework-go](https://github.com/microsoft/agent-framework-go) port.

## Changes

### Infrastructure
- **zone-pivot-groups.yml** — Added `programming-language-go` pivot
- **copilot-instructions.md** — Updated language lists and sample repo references

### Get Started (6 pages) — Full Go tutorials
- your-first-agent, add-tools, multi-turn, memory, workflows, hosting

### Real Go documentation (38 pages)
Replaced placeholder zones with actual Go code samples and API documentation for all features that agent-framework-go supports:

- **Agents**: overview, running agents, structured output, observability, multimodal, skills, pipeline architecture, background responses
- **Tools**: overview, function tools, MCP tools, hosted MCP, tool approval, file search, web search, code interpreter
- **Middleware**: overview, defining middleware
- **Conversations**: overview, sessions, storage, context providers
- **Providers**: overview, OpenAI, Azure OpenAI, Anthropic, custom
- **Workflows**: overview, executors, edges, events, state, checkpoints, agents in workflows, human-in-the-loop, observability
- **Integrations**: A2A protocol
- **Overview**: getting started with Go

### Placeholder zones (~50 pages)
Pages for features not yet ported to Go (declarative agents, orchestrations, DevUI, RAG, compaction, etc.) have a "coming soon" note linking to the Go repository.

## Code sample sources
All Go code samples are verified against the actual source code in [microsoft/agent-framework-go](https://github.com/microsoft/agent-framework-go). Inline code blocks are used (no cross-repo snippet references) since the learn-build-service GitHub App is not yet installed on the Go repo.

## Build warnings
The `pivot-id-unused` warnings from the first build run are resolved in the second commit, which adds Go zones to all pages using the `programming-languages` pivot group.