### PR TITLE
Remove old `WithOpenTelemetry` method

### DIFF
--- a/agent-framework/agents/observability.md
+++ b/agent-framework/agents/observability.md
@@ -47,7 +47,10 @@ var agent = new ChatClientAgent(
     name: "OpenTelemetryDemoAgent",
     instructions: "You are a helpful assistant that provides concise and informative responses.",
     tools: [AIFunctionFactory.Create(GetWeatherAsync)]
-).WithOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true); // Enable OpenTelemetry instrumentation with sensitive data
+)
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: (cfg) => cfg.EnableSensitiveData = true) // Enable OpenTelemetry instrumentation with sensitive data
+    .Build();
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
In the observability doc, there was a reference to `WithOpenTelemetry` that has been removed in this PR https://github.com/microsoft/agent-framework/pull/1033