### PR TITLE
Clarify CopilotKit Runtime guidance for AG-UI

### DIFF
--- a/agent-framework/integrations/ag-ui/index.md
+++ b/agent-framework/integrations/ag-ui/index.md
@@ -5,7 +5,7 @@ zone_pivot_groups: programming-languages
 author: moonbox3
 ms.topic: overview
 ms.author: evmattso
-ms.date: 11/07/2025
+ms.date: 06/15/2026
 ms.service: agent-framework
 ---
 
@@ -48,10 +48,11 @@ The Agent Framework AG-UI integration supports all 7 AG-UI protocol features:
 
 ## Build agent UIs with CopilotKit
 
-[CopilotKit](https://copilotkit.ai/) provides rich UI components for building agent user interfaces based on the standard AG-UI protocol. CopilotKit supports streaming chat interfaces, frontend & backend tool calling, human-in-the-loop interactions, generative UI, shared state, and much more. You can see a examples of the various agent UI scenarios that CopilotKit supports in the [AG-UI Dojo](https://dojo.ag-ui.com/microsoft-agent-framework-dotnet) sample application.
+[CopilotKit](https://copilotkit.ai/) provides rich UI components for building agent user interfaces based on the standard AG-UI protocol. CopilotKit supports streaming chat interfaces, frontend and backend tool calling, human-in-the-loop interactions, generative UI, shared state, and much more. You can see examples of the various agent UI scenarios that CopilotKit supports in the [AG-UI Dojo](https://dojo.ag-ui.com/microsoft-agent-framework-dotnet) sample application.
 
-CopilotKit helps you focus on your agent’s capabilities while delivering a polished user experience without reinventing the wheel.
-To learn more about getting started with Microsoft Agent Framework and CopilotKit, see the [Microsoft Agent Framework integration for CopilotKit](https://docs.copilotkit.ai/microsoft-agent-framework) documentation.
+For production applications, use the [Copilot Runtime](https://docs.copilotkit.ai/backend/copilot-runtime) as the server-side connection layer between your user-facing application and your Agent Framework AG-UI endpoint. The runtime keeps the agent connection on your server, where you can enforce authentication, route requests, apply AG-UI middleware, and enable CopilotKit features such as frontend tools, generative UI, human-in-the-loop flows, shared state, observability, and MCP Apps.
+
+Direct AG-UI client connections are useful for local development and protocol testing. For deployed applications, prefer the Copilot Runtime or another trusted frontend server so browser and mobile clients do not connect directly to the AG-UI server. To learn more about getting started with Microsoft Agent Framework and CopilotKit, see the [Microsoft Agent Framework integration for CopilotKit](https://docs.copilotkit.ai/microsoft-agent-framework) documentation.
 
 ::: zone pivot="programming-language-csharp"
 

--- a/agent-framework/integrations/ag-ui/security-considerations.md
+++ b/agent-framework/integrations/ag-ui/security-considerations.md
@@ -4,13 +4,13 @@ description: Essential security guidelines for building secure AG-UI application
 author: moonbox3
 ms.topic: reference
 ms.author: evmattso
-ms.date: 11/11/2025
+ms.date: 06/15/2026
 ms.service: agent-framework
 ---
 
 # Security Considerations for AG-UI
 
-AG-UI enables powerful real-time interactions between clients and AI agents. This bidirectional communication requires some security considerations. The following document  covers essential security practices for building securing your agents exposed through AG-UI.
+AG-UI enables powerful real-time interactions between clients and AI agents. This bidirectional communication requires some security considerations. The following document covers essential security practices for securing your agents exposed through AG-UI.
 
 ## Overview
 
@@ -40,6 +40,8 @@ The primary trust boundary in AG-UI is between the client and the AG-UI server. 
 
 > [!IMPORTANT]
 > **Do not expose AG-UI servers directly to untrusted clients** (e.g., JavaScript running in browsers, mobile apps). Instead, implement a trusted frontend server that mediates communication and constructs AG-UI protocol messages in a controlled manner. This prevents malicious clients from crafting arbitrary protocol messages.
+
+If you build the user interface with [CopilotKit](https://copilotkit.ai/), the [Copilot Runtime](https://docs.copilotkit.ai/backend/copilot-runtime) can serve as this trusted frontend server. It runs on your server, connects to the AG-UI endpoint from a trusted environment, and gives your application a place to enforce authentication, validate requests, control available tools, and apply middleware before traffic reaches the agent.
 
 ### Potential threats
 
@@ -99,6 +101,8 @@ When using a trusted frontend server, the security model changes significantly:
 
 > [!TIP]
 > The trusted frontend server pattern significantly reduces attack surface by ensuring that only user message **content** comes from untrusted sources, while all other protocol elements (message structure, roles, tools, state, context) are controlled by trusted code.
+
+When using a runtime or proxy layer, keep authorization decisions in that trusted layer. For example, decide which tools, state fields, context values, and forwarded properties a user can send before constructing the AG-UI request to the server.
 
 ## Input Validation and Sanitization
 


### PR DESCRIPTION
## Summary
- Clarifies CopilotKit Runtime as the server-side connection layer for production Agent Framework AG-UI apps.
- Adds Copilot Runtime to the AG-UI security guidance as a concrete trusted frontend server option.
- Fixes small copy issues in the AG-UI overview and security pages.

## Notes
- This intentionally avoids .NET package/API snippet changes while the AG-UI .NET SDK work is still in draft.

## Validation
- git diff --check