### PR TITLE
Clarify CopilotKit AG-UI guidance

### DIFF
--- a/agent-framework/integrations/ag-ui/index.md
+++ b/agent-framework/integrations/ag-ui/index.md
@@ -48,12 +48,9 @@ The Agent Framework AG-UI integration supports all 7 AG-UI protocol features:
 
 ## Build agent UIs with CopilotKit
 
-[CopilotKit](https://copilotkit.ai/) provides rich UI components for building agent user interfaces based on the standard AG-UI protocol. CopilotKit supports streaming chat interfaces, frontend & backend tool calling, human-in-the-loop interactions, generative UI, shared state, and much more. You can see examples of the various agent UI scenarios that CopilotKit supports in the [AG-UI Dojo](https://dojo.ag-ui.com/microsoft-agent-framework-dotnet) sample application.
+[CopilotKit](https://copilotkit.ai/) provides rich UI components and headless UI primitives for building agent user interfaces based on the standard AG-UI protocol, so you can ship quickly with prebuilt chat experiences or fully customize the interface for your application. CopilotKit supports streaming chat interfaces, frontend and backend tool calling, human-in-the-loop interactions, generative UI, shared state, and much more. You can see examples of the various agent UI scenarios that CopilotKit supports in the [AG-UI Dojo](https://dojo.ag-ui.com/microsoft-agent-framework-dotnet) sample application.
 
-To connect a CopilotKit React frontend to an Agent Framework AG-UI backend, register your endpoint as an `HttpAgent` in the CopilotKit runtime. This allows CopilotKit's frontend tools to flow through as AG-UI client tools, and all AG-UI features (streaming, approvals, state sync) work automatically.
-
-CopilotKit helps you focus on your agent’s capabilities while delivering a polished user experience without reinventing the wheel.
-To learn more about getting started with Microsoft Agent Framework and CopilotKit, see the [Microsoft Agent Framework integration for CopilotKit](https://docs.copilotkit.ai/microsoft-agent-framework) documentation.
+CopilotKit helps you focus on your agent's capabilities while delivering a polished user experience without reinventing the wheel. To learn more about getting started with Microsoft Agent Framework and CopilotKit, see the [Microsoft Agent Framework integration for CopilotKit](https://docs.copilotkit.ai/microsoft-agent-framework) documentation.
 
 ::: zone pivot="programming-language-csharp"
 

--- a/agent-framework/integrations/ag-ui/security-considerations.md
+++ b/agent-framework/integrations/ag-ui/security-considerations.md
@@ -10,7 +10,7 @@ ms.service: agent-framework
 
 # Security Considerations for AG-UI
 
-AG-UI enables powerful real-time interactions between clients and AI agents. This bidirectional communication requires some security considerations. The following document  covers essential security practices for building securing your agents exposed through AG-UI.
+AG-UI enables powerful real-time interactions between clients and AI agents. This bidirectional communication requires some security considerations. The following document covers essential security practices for securing your agents exposed through AG-UI.
 
 ## Overview
 
@@ -100,6 +100,8 @@ When using a trusted frontend server, the security model changes significantly:
 > [!TIP]
 > The trusted frontend server pattern significantly reduces attack surface by ensuring that only user message **content** comes from untrusted sources, while all other protocol elements (message structure, roles, tools, state, context) are controlled by trusted code.
 
+When using a proxy or trusted server layer, keep authorization decisions in that trusted layer. For example, decide which tools, state fields, context values, and forwarded properties a user can send before constructing the AG-UI request to the server.
+
 ## Input Validation and Sanitization
 
 ### Message Content Validation
@@ -148,7 +150,7 @@ Forwarded properties contain arbitrary JSON that passes through the system. Trea
 
 ## Authentication and Authorization
 
-AG-UI does not include built-in authorization mechanism. It is up to your application to prevent unauthorized use of the exposed AG-UI endpoint. 
+AG-UI does not include a built-in authorization mechanism. It is up to your application to prevent unauthorized use of the exposed AG-UI endpoint.
 
 ### Approval State Storage
 

--- a/agent-framework/integrations/ag-ui/testing-with-dojo.md
+++ b/agent-framework/integrations/ag-ui/testing-with-dojo.md
@@ -31,7 +31,7 @@ Before you begin, ensure you have:
 First, clone the AG-UI repository which contains the Dojo application and Microsoft Agent Framework integration examples:
 
 ```bash
-git clone https://github.com/ag-oss/ag-ui.git
+git clone https://github.com/ag-ui-protocol/ag-ui.git
 cd ag-ui
 ```
 


### PR DESCRIPTION
## Summary
- Clarifies CopilotKit's AG-UI positioning by mentioning both rich UI components and headless UI primitives.
- Keeps the Agent Framework AG-UI overview focused on current CopilotKit capabilities without adding hosting-specific guidance.
- Tightens generic AG-UI security guidance around authorization decisions in a trusted server/proxy layer.
- Fixes small copy issues and updates the AG-UI Dojo clone URL to the current repository.

## Notes
- Hosting-specific Copilot Runtime guidance is intentionally deferred until there is a Foundry Hosted Agents sample to link to.

## Validation
- git diff --check
