### PR TITLE
Fix AG-UI backend tool rendering example — broken imports and API changes

### DIFF
--- a/agent-framework/integrations/ag-ui/backend-tool-rendering.md
+++ b/agent-framework/integrations/ag-ui/backend-tool-rendering.md
@@ -508,7 +508,7 @@ Here's an enhanced client using `AGUIChatClient` that displays tool execution:
 import asyncio
 import os
 
-from agent_framework import Agent, ToolCallContent, ToolResultContent
+from agent_framework import Agent
 from agent_framework_ag_ui import AGUIChatClient
 
 
@@ -518,7 +518,7 @@ async def main():
     print(f"Connecting to AG-UI server at: {server_url}\n")
 
     # Create AG-UI chat client
-    chat_client = AGUIChatClient(server_url=server_url)
+    chat_client = AGUIChatClient(endpoint=server_url)
     
     # Create agent with the chat client
     agent = Agent(
@@ -546,11 +546,16 @@ async def main():
                     print(f"\033[96m{update.text}\033[0m", end="", flush=True)
                 
                 # Display tool calls and results
-                for content in update.contents:
-                    if isinstance(content, ToolCallContent):
-                        print(f"\n\033[95m[Calling tool: {content.name}]\033[0m")
-                    elif isinstance(content, ToolResultContent):
-                        result_text = content.result if isinstance(content.result, str) else str(content.result)
+                for content in (update.contents or []):
+                    content_type = getattr(content, "type", "")
+                    if content_type == "function_call":
+                        tool_name = getattr(content, "name", None) or "unknown"
+                        print(f"\n\033[95m[Calling tool: {tool_name}]\033[0m")
+                    elif content_type in {"function_result", "tool_result"}:
+                        result = getattr(content, "result", None)
+                        if result is None:
+                            result = getattr(content, "tool_result", None)
+                        result_text = result if isinstance(result, str) else str(result)
                         print(f"\033[94m[Tool result: {result_text}]\033[0m")
 
             print("\n")


### PR DESCRIPTION
## Fixes #406

### Problem
The AG-UI backend tool rendering example in `backend-tool-rendering.md` throws an `ImportError` when executed:

`
from agent_framework import Agent, ToolCallContent, ToolResultContent
ImportError: cannot import name 'ToolCallContent' from 'agent_framework'
`

The `ToolCallContent` and `ToolResultContent` classes were removed/renamed in recent agent-framework releases, breaking the documented example.

### Changes

1. **Removed broken imports** — `ToolCallContent` and `ToolResultContent` no longer exist in `agent_framework`. Changed import to just `from agent_framework import Agent`

2. **Fixed `AGUIChatClient` constructor** — Changed from positional `server_url` to keyword `endpoint=server_url` to match current API

3. **Replaced `isinstance()` checks with `getattr()` type-string checking** — More resilient to API changes:
   - `isinstance(content, ToolCallContent)` → `getattr(content, 'type', '') == 'function_call'`
   - `isinstance(content, ToolResultContent)` → `content_type in {'function_result', 'tool_result'}`

4. **Added null guard** — `update.contents` → `(update.contents or [])` to prevent `TypeError` on `None`

### Testing
Verified the corrected code follows the working pattern reported by @mjmadhu in #406.

### Context
I'm an active contributor to the [microsoft/agent-framework](https://github.com/microsoft/agent-framework) repo (PRs [#6642](https://github.com/microsoft/agent-framework/pull/6642) and [#6643](https://github.com/microsoft/agent-framework/pull/6643)) and encountered these same API changes while working on the Python hosting stack.