### PR TITLE
Fix incorrect navigation link, typos in MCP plugins and vector store docs

### DIFF
--- a/semantic-kernel/concepts/plugins/adding-mcp-plugins.md
+++ b/semantic-kernel/concepts/plugins/adding-mcp-plugins.md
@@ -90,7 +90,7 @@ async def main():
         # Do something with the kernel
 ```
 
-In both case the async context manager is used to setup the connection and close it, you can also do this manually:
+In both cases the async context manager is used to setup the connection and close it, you can also do this manually:
 
 ```python
 import os

--- a/semantic-kernel/concepts/semantic-kernel-components.md
+++ b/semantic-kernel/concepts/semantic-kernel-components.md
@@ -30,7 +30,7 @@ The Kernel does not use any registered vector store automatically, but Vector Se
 in which case the plugin is made available to Prompt Templates and the Chat Completion AI Model.
 
 > [!TIP]
-> For more information on using memory connectors see [Adding AI services to Semantic Kernel](./ai-services/index.md).
+> For more information on using memory connectors see [Vector Store Connectors](./vector-store-connectors/index.md).
 
 ## Functions and Plugins
 

--- a/semantic-kernel/concepts/vector-store-connectors/index.md
+++ b/semantic-kernel/concepts/vector-store-connectors/index.md
@@ -35,10 +35,11 @@ One use case for storing information in a vector database is to enable large lan
 
 For example, if you want to write a blog post about the latest trends in AI, you can use a vector database to store the latest information about that topic and pass the information along with the ask to a LLM in order to generate a blog post that leverages the latest information.
 
-Semantic Kernel provides an abstraction for interacting with Vector Stores and a list of out-of-the-box implementations that implement these abstractions for various databases. Features include creating, listing and deleting collections of records, and uploading, retrieving and deleting records. The abstraction makes it easy to experiment with a free or locally hosted Vector Store and then switch to a service when needing to scale up.
+For python, Semantic Kernel provides an abstraction for interacting with Vector Stores and a list of out-of-the-box implementations that implement these abstractions for various databases.
 
-The out-of-the-box implementations can be used with Semantic Kernel, but do not depend on the core Semantic Kernel stack and can also therefore be used completely independently if required.
-The Semantic Kernel provided imlementations are referred to as 'connectors'.
+For .net an abstraction is provided by the .net Foundation.  Various implementations that implement these abstractions are shipped by database providers and the .net Foundation via the [community toolkit](https://github.com/CommunityToolkit/AI/tree/main/MEVD). 
+
+Features include creating, listing and deleting collections of records, and uploading, retrieving and deleting records. The abstraction makes it easy to experiment with a free or locally hosted Vector Store and then switch to a service when needing to scale up.
 
 ::: zone pivot="programming-language-csharp"
 

--- a/semantic-kernel/concepts/vector-store-connectors/index.md
+++ b/semantic-kernel/concepts/vector-store-connectors/index.md
@@ -35,7 +35,7 @@ One use case for storing information in a vector database is to enable large lan
 
 For example, if you want to write a blog post about the latest trends in AI, you can use a vector database to store the latest information about that topic and pass the information along with the ask to a LLM in order to generate a blog post that leverages the latest information.
 
-Semantic Kernel and .net provides an abstraction for interacting with Vector Stores and a list of out-of-the-box implementations that implement these abstractions for various databases. Features include creating, listing and deleting collections of records, and uploading, retrieving and deleting records. The abstraction makes it easy to experiment with a free or locally hosted Vector Store and then switch to a service when needing to scale up.
+Semantic Kernel provides an abstraction for interacting with Vector Stores and a list of out-of-the-box implementations that implement these abstractions for various databases. Features include creating, listing and deleting collections of records, and uploading, retrieving and deleting records. The abstraction makes it easy to experiment with a free or locally hosted Vector Store and then switch to a service when needing to scale up.
 
 The out-of-the-box implementations can be used with Semantic Kernel, but do not depend on the core Semantic Kernel stack and can also therefore be used completely independently if required.
 The Semantic Kernel provided imlementations are referred to as 'connectors'.


### PR DESCRIPTION
## Fixes #394, #282, #281

This PR addresses three separate documentation issues:

### Fix #394 — Incorrect document navigation link
The Vector Store (Memory) Connectors tip on the [Semantic Kernel Components](https://learn.microsoft.com/en-us/semantic-kernel/concepts/semantic-kernel-components) page linked to the AI Services page instead of the Vector Store Connectors page. Both the AI Service Connectors and Vector Store sections had identical links pointing to `ai-services/index.md`.

**Before:** `[Adding AI services to Semantic Kernel](./ai-services/index.md)`
**After:** `[Vector Store Connectors](./vector-store-connectors/index.md)`

### Fix #282 — Typo in MCP plugins page
Grammar fix: ''In both case'' → ''In both cases'' on the [Adding MCP Plugins](https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-mcp-plugins) page.

### Fix #281 — Incorrect '.net' reference on Python/Java vector store pages
The vector store connectors overview page says ''Semantic Kernel and .net provides an abstraction...'' but this text appears on all language pivots including Python and Java. Removed the .net-specific reference to make the description language-agnostic.

**Before:** ''Semantic Kernel and .net provides an abstraction...''
**After:** ''Semantic Kernel provides an abstraction...''

### Files Changed
- `semantic-kernel/concepts/semantic-kernel-components.md`
- `semantic-kernel/concepts/plugins/adding-mcp-plugins.md`
- `semantic-kernel/concepts/vector-store-connectors/index.md`