### PR TITLE
Fix typo error in human-in-the-loop.md

### DIFF
--- a/agent-framework/workflows/human-in-the-loop.md
+++ b/agent-framework/workflows/human-in-the-loop.md
@@ -189,7 +189,7 @@ A `RequestPort` defines a typed request/response channel between the workflow an
 
 ::: zone pivot="programming-language-csharp"
 
-An `RequestPort` emits a `RequestInfoEvent` when it receives a request. You can subscribe to these events to handle incoming requests from the workflow. When you receive a response from an external system, send it back to the workflow using the response mechanism. The framework automatically routes the response to the executor that sent the original request.
+A `RequestPort` emits a `RequestInfoEvent` when it receives a request. You can subscribe to these events to handle incoming requests from the workflow. When you receive a response from an external system, send it back to the workflow using the response mechanism. The framework automatically routes the response to the executor that sent the original request.
 
 ```csharp
 await using StreamingRun handle = await InProcessExecution.RunStreamingAsync(workflow, NumberSignal.Init);


### PR DESCRIPTION
Fixed typo error text in the Handling Requests and Responses section.